### PR TITLE
Moved the zmq socket addresses to config file

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -27,6 +27,12 @@
     "second_stage_filter_transition" : "50.0e3",
     "third_stage_filter_cutoff" : "3.333e3",
     "third_stage_filter_transition" : "0.833e3"
+    "driver_to_rx_dsp_address" : "tcp://127.0.0.1:5000",
+    "radar_control_to_rx_dsp_address" : "tcp://127.0.0.1:5001",
+    "radar_control_to_driver_address" : "tcp://127.0.0.1:5002",
+    "rx_dsp_to_radar_control_ack_address" : "tcp://127.0.0.1:5003",
+    "rx_dsp_to_radar_control_timing_address" : "tcp://127.0.0.1:5004"
+    ""
 }
 
 

--- a/utils/driver_options/driveroptions.cpp
+++ b/utils/driver_options/driveroptions.cpp
@@ -43,6 +43,10 @@ DriverOptions::DriverOptions() {
                                 config_pt.get<std::string>("main_antenna_count"));
     interferometer_antenna_count = boost::lexical_cast<uint32_t>(
                                 config_pt.get<std::string>("interferometer_antenna_count"));
+    radar_control_socket_address = config_pt.get<std::string>("radar_control_to_driver_address");
+    rx_dsp_socket_address = config_pt.get<std::string>("driver_to_rx_dsp_address");
+
+
 }
 
 double DriverOptions::get_tx_rate() {
@@ -119,4 +123,11 @@ uint32_t DriverOptions::get_main_antenna_count() {
 
 uint32_t DriverOptions::get_interferometer_antenna_count() {
     return interferometer_antenna_count;
+}
+
+std::string DriverOptions::get_radar_control_socket_address() {
+    return radar_control_socket_address;
+}
+std::string DriverOptions::get_rx_dsp_socket_address() {
+    return rx_dsp_socket_address;
 }

--- a/utils/driver_options/driveroptions.hpp
+++ b/utils/driver_options/driveroptions.hpp
@@ -28,6 +28,8 @@ class DriverOptions: public Options {
         double get_tr_window_time();
         uint32_t get_main_antenna_count();
         uint32_t get_interferometer_antenna_count();
+        std::string get_radar_control_socket_address();
+        std::string get_rx_dsp_socket_address();
 
  private:
         std::string devices;
@@ -49,6 +51,10 @@ class DriverOptions: public Options {
         double tr_window_time;
         uint32_t main_antenna_count;
         uint32_t interferometer_antenna_count;
+        std::string radar_control_socket_address;
+        std::string rx_dsp_socket_address;
+        
+
 };
 
 #endif

--- a/utils/signal_processing_options/signalprocessingoptions.cpp
+++ b/utils/signal_processing_options/signalprocessingoptions.cpp
@@ -1,7 +1,6 @@
 /*Copyright 2016 SuperDARN*/
 #include <boost/property_tree/ini_parser.hpp>
 #include <boost/range/algorithm_ext/erase.hpp>
-#include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 #include <string>
 #include "utils/options/options.hpp"
@@ -33,7 +32,12 @@ SignalProcessingOptions::SignalProcessingOptions() {
                                 config_pt.get<std::string>("main_antenna_count"));
     interferometer_antenna_count = boost::lexical_cast<uint32_t>(
                                 config_pt.get<std::string>("interferometer_antenna_count"));
+    driver_socket_address = config_pt.get<std::string>("driver_to_rx_dsp_address");
+    radar_control_socket_address =  config_pt.get<std::string>("radar_control_to_rx_dsp_address");
+    ack_socket_address = config_pt.get<std::string>("rx_dsp_to_radar_control_ack_address");
+    timing_socket_address = config_pt.get<std::string>("rx_dsp_to_radar_control_timing_address");
 }
+
 
 uint32_t SignalProcessingOptions::get_main_antenna_count() {
     return main_antenna_count;
@@ -76,4 +80,20 @@ double SignalProcessingOptions::get_third_stage_filter_cutoff(){
 
 double SignalProcessingOptions::get_third_stage_filter_transition(){
     return third_stage_filter_transition;
+}
+
+std::string SignalProcessingOptions::get_driver_socket_address(){
+    return driver_socket_address;
+}
+
+std::string SignalProcessingOptions::get_radar_control_socket_address(){
+    return radar_control_socket_address;
+}
+
+std::string SignalProcessingOptions::get_ack_socket_address(){
+    return ack_socket_address;
+}
+
+std::string SignalProcessingOptions::get_timimg_socket_address(){
+    return timing_socket_address;
 }

--- a/utils/signal_processing_options/signalprocessingoptions.hpp
+++ b/utils/signal_processing_options/signalprocessingoptions.hpp
@@ -21,6 +21,10 @@ class SignalProcessingOptions: public Options {
     double get_third_stage_filter_transition();
     uint32_t get_main_antenna_count();
     uint32_t get_interferometer_antenna_count();
+    std::string get_driver_socket_address();
+    std::string get_radar_control_socket_address();
+    std::string get_ack_socket_address();
+    std::string get_timimg_socket_address();
 
  private:
     uint32_t main_antenna_count;
@@ -34,6 +38,10 @@ class SignalProcessingOptions: public Options {
     double second_stage_filter_transition;
     double third_stage_filter_cutoff;
     double third_stage_filter_transition;
+    std::string driver_socket_address;
+    std::string radar_control_socket_address;
+    std::string ack_socket_address;
+    std::string timing_socket_address;
 
 
 };


### PR DESCRIPTION
I created config options for interprocess socket connections so that the addresses can be grouped in a common place. This will let people easily change the transport protocol or ports if need be.