### PR TITLE
Octoclock testing

### DIFF
--- a/testing/octoclock_test/SConscript
+++ b/testing/octoclock_test/SConscript
@@ -1,0 +1,33 @@
+# Copyright 2015 The Ostrich / by Itamar O
+# Copyright 2016 SuperDARN
+
+# The MIT License (MIT)
+
+# Copyright (c) 2014 The Ostrich
+# Modified 2016 SuperDARN
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+""""""
+import os
+
+Import('*')
+
+Prog('octoclock_test', Glob("./*.c*"),
+     LIBS=['uhd','boost_system', 'boost_program_options'])

--- a/testing/octoclock_test/octoclock_test.cpp
+++ b/testing/octoclock_test/octoclock_test.cpp
@@ -23,7 +23,9 @@
 namespace po = boost::program_options;            // Options on command line or config file
 
 float speed_of_light = 299792458.0; // meters per second
-static const std::string  DEVICE_DEFAULT_MULTI_USRP_ARGS          = "addr0=192.168.10.130,addr1=192.168.10.131,addr2=192.168.132";
+static const std::string  DEVICE_DEFAULT_MULTI_USRP_CLOCK_ARGS          = "addr0=192.168.10.130,addr1=192.168.10.131,addr2=192.168.132";
+static const uint32_t UPDATE_PERIOD_IN_S				= 10;
+
 
 // Signal handling (CTRL-C)
 static bool stop_signal_called = false;
@@ -36,6 +38,8 @@ int main(int argc, char *argv[]) {
 
   // Variables for program options
   std::string multi_usrp_clock_args;
+
+  uint32_t update_period_in_s;
 
   // Set up program options
   po::options_description config("Configuration");
@@ -79,9 +83,9 @@ int main(int argc, char *argv[]) {
   while (not stop_signal_called) {
     // If user asked for updates, then print out every x seconds, otherwise just sleep
     if (vm.count("print_time")) {
-      printf("Octoclock 0 time: %d\n",uhd::usrp_clock::multi_usrp_clock::get_time(0));
-      printf("Octoclock 1 time: %d\n",uhd::usrp_clock::multi_usrp_clock::get_time(1));
-      printf("Octoclock 2 time: %d\n",uhd::usrp_clock::multi_usrp_clock::get_time(2));
+      std::cout << "Octoclock 0 time: " << clock->get_time(0) << std::endl;
+      std::cout << "Octoclock 1 time: " << clock->get_time(1) << std::endl;
+      std::cout << "Octoclock 2 time: " << clock->get_time(2) << std::endl;
 	
       sleep(update_period_in_s);
     } else {

--- a/testing/octoclock_test/octoclock_test.cpp
+++ b/testing/octoclock_test/octoclock_test.cpp
@@ -23,7 +23,7 @@
 namespace po = boost::program_options;            // Options on command line or config file
 
 float speed_of_light = 299792458.0; // meters per second
-static const std::string  DEVICE_DEFAULT_MULTI_USRP_CLOCK_ARGS          = "addr0=192.168.10.130,addr1=192.168.10.131,addr2=192.168.132";
+static const std::string  DEVICE_DEFAULT_MULTI_USRP_CLOCK_ARGS          = "addr0=192.168.10.130,addr1=192.168.10.131,addr2=192.168.10.132";
 static const uint32_t UPDATE_PERIOD_IN_S				= 10;
 
 
@@ -74,20 +74,42 @@ int main(int argc, char *argv[]) {
     std::cout << "Failed to get usrp clock device" << std::endl;
     return -1;
   }
-
   if(vm.count("print_diagnostic_info")) {
-    
-    return 0;
-  } 
+    std::cout << "Octoclock number of boards: " << clock->get_num_boards() << std::endl;
+    std::cout << clock->get_pp_string() << std::endl;
+    for ( size_t boardnumber = 0; boardnumber < clock->get_num_boards(); boardnumber++) {
+      std::cout << "Octoclock board: " << boardnumber << std::endl;
+      std::cout << "  gps detected: " << clock->get_sensor("gps_detected", boardnumber).value << std::endl;
+      std::cout << "  reference: " << clock->get_sensor("using_ref",boardnumber).value << std::endl;
+      std::cout << "  external reference detected: " << clock->get_sensor("ext_ref_detected",boardnumber).value << std::endl;
+      std::cout << "  switch position: " << clock->get_sensor("switch_pos",boardnumber).value << std::endl;
+      if(clock->get_sensor("gps_detected", boardnumber).value == "true") {
+	std::cout << std::endl << "GPS sentences" << std::endl;
+        std::cout << clock->get_sensor("gps_gpgga", boardnumber).value << std::endl;
+        std::cout << clock->get_sensor("gps_gprmc", boardnumber).value << std::endl;
+        std::cout << "GPS Time: " << clock->get_sensor("gps_time", boardnumber).value << std::endl;
+        std::cout << "GPS locked: " << clock->get_sensor("gps_locked", boardnumber).value << std::endl;
+        std::cout << "GPS servo status: " << clock->get_sensor("gps_servo", boardnumber).value << std::endl;
+	std::cout << std::endl;
+      }
+    }
+  }
 
   while (not stop_signal_called) {
     // If user asked for updates, then print out every x seconds, otherwise just sleep
     if (vm.count("print_time")) {
-      std::cout << "Octoclock 0 time: " << clock->get_time(0) << std::endl;
-      std::cout << "Octoclock 1 time: " << clock->get_time(1) << std::endl;
-      std::cout << "Octoclock 2 time: " << clock->get_time(2) << std::endl;
-	
+    	for ( size_t boardnumber = 0; boardnumber < clock->get_num_boards(); boardnumber++) {
+        if(clock->get_sensor("gps_detected", boardnumber).value == "true") {
+	std::cout << std::endl << "GPS sentences" << std::endl;
+        std::cout << clock->get_sensor("gps_gpgga", boardnumber).value << std::endl;
+        std::cout << clock->get_sensor("gps_gprmc", boardnumber).value << std::endl;
+        std::cout << "GPS Time: " << clock->get_sensor("gps_time", boardnumber).value << std::endl;
+        std::cout << "GPS locked: " << clock->get_sensor("gps_locked", boardnumber).value << std::endl;
+        std::cout << "GPS servo status: " << clock->get_sensor("gps_servo", boardnumber).value << std::endl;
+	std::cout << std::endl;
+        }
       sleep(update_period_in_s);
+    }
     } else {
       sleep(1);
     }
@@ -95,7 +117,6 @@ int main(int argc, char *argv[]) {
   std::cout << "Stop signal called, exiting" << std::endl;
   return 0;
 }
-
 
   
 

--- a/testing/octoclock_test/octoclock_test.cpp
+++ b/testing/octoclock_test/octoclock_test.cpp
@@ -1,0 +1,97 @@
+// octoclock test code 
+// 201712 - Kevin Krieger
+
+#include <stdlib.h>
+
+#include <chrono>
+#include <csignal>
+#include <fstream>
+#include <iostream>
+//#include <thread>
+
+#include <boost/cstdint.hpp>
+#include <boost/format.hpp>
+#include <boost/program_options.hpp>
+#include <boost/thread/thread.hpp>
+
+#include <uhd/utils/safe_main.hpp>
+#include <uhd/utils/thread_priority.hpp>
+#include <uhd/usrp_clock/multi_usrp_clock.hpp>
+
+// Test program for Ettus Octoclocks
+// .130 and .132 are regular octoclocks, externally referenced off of .131, which is an octoclock-g (GPS unit built-in)
+namespace po = boost::program_options;            // Options on command line or config file
+
+float speed_of_light = 299792458.0; // meters per second
+static const std::string  DEVICE_DEFAULT_MULTI_USRP_ARGS          = "addr0=192.168.10.130,addr1=192.168.10.131,addr2=192.168.132";
+
+// Signal handling (CTRL-C)
+static bool stop_signal_called = false;
+void sig_int_handler(int) {stop_signal_called = true;}
+
+int main(int argc, char *argv[]) {
+
+  // register signal handler
+  std::signal(SIGINT, &sig_int_handler);
+
+  // Variables for program options
+  std::string multi_usrp_clock_args;
+
+  // Set up program options
+  po::options_description config("Configuration");
+  config.add_options()
+    ("help", "help message")
+    ("multi_usrp_clock_args", po::value<std::string>(&multi_usrp_clock_args)->default_value(DEVICE_DEFAULT_MULTI_USRP_CLOCK_ARGS)->composing(), "multi usrp clock address args")
+    ("print_diagnostic_info,d", "Print out various information about the devices and exit")
+    ("print_time,g", "Print out the time from the octoclocks periodically (period defined by update_period)")
+    ("update_period", po::value<uint32_t>(&update_period_in_s)->default_value(UPDATE_PERIOD_IN_S), "If printing values, how often to print them (s)")
+  ;
+
+  po::positional_options_description p;
+  po::variables_map vm;
+  po::store(po::command_line_parser(argc, argv).options(config).positional(p).run(), vm);
+  std::ifstream config_filename("octoclock_test.cfg");
+  po::store(po::parse_config_file(config_filename, config, false), vm);
+  po::notify(vm);
+
+  std::cout << std::endl;
+
+  // Print help messages
+  if (vm.count("help")) {
+    std::cout << config << std::endl;
+    return 0;
+  }
+
+  // Create multi usrp clock device (get shared pointer) 
+  uhd::usrp_clock::multi_usrp_clock::sptr clock;
+  try {
+    clock = uhd::usrp_clock::multi_usrp_clock::make(multi_usrp_clock_args);
+  } catch(...) {
+    std::cout << "Failed to get usrp clock device" << std::endl;
+    return -1;
+  }
+
+  if(vm.count("print_diagnostic_info")) {
+    
+    return 0;
+  } 
+
+  while (not stop_signal_called) {
+    // If user asked for updates, then print out every x seconds, otherwise just sleep
+    if (vm.count("print_time")) {
+      printf("Octoclock 0 time: %d\n",uhd::usrp_clock::multi_usrp_clock::get_time(0));
+      printf("Octoclock 1 time: %d\n",uhd::usrp_clock::multi_usrp_clock::get_time(1));
+      printf("Octoclock 2 time: %d\n",uhd::usrp_clock::multi_usrp_clock::get_time(2));
+	
+      sleep(update_period_in_s);
+    } else {
+      sleep(1);
+    }
+  }
+  std::cout << "Stop signal called, exiting" << std::endl;
+  return 0;
+}
+
+
+  
+


### PR DESCRIPTION
new small test code for octoclocks. Currently hardcoded 3 ip addresses.
Queries and prints all information available from octoclocks, including nmea sentences.
Note that the update_delay is very rough, as there is delay in querying the octoclock gps information
usage: ./octoclock_test --help