### PR TITLE
Added export of BOREALIS_PATH variable if user supplied a proper flav…

### DIFF
--- a/mode
+++ b/mode
@@ -81,6 +81,7 @@ for FLAVOR in $FLAVORS; do
         path_prepend "$FLAV_BIN"
         # Update prompt with colored flavor decoration
         export PS1="\[\e[0;36m\]($FLAVOR)\[\e[m\] $CLEAN_PS"
+	export BOREALIS_PATH="$BASE_DIR"
     else
         # Not requested flavor - remove from PATH
         path_remove "$FLAV_BIN"

--- a/mode
+++ b/mode
@@ -81,7 +81,7 @@ for FLAVOR in $FLAVORS; do
         path_prepend "$FLAV_BIN"
         # Update prompt with colored flavor decoration
         export PS1="\[\e[0;36m\]($FLAVOR)\[\e[m\] $CLEAN_PS"
-	export BOREALIS_PATH="$BASE_DIR"
+	export BOREALISPATH="$BASE_DIR"
     else
         # Not requested flavor - remove from PATH
         path_remove "$FLAV_BIN"


### PR DESCRIPTION
…our (typically debug or release). The variable just tracks the base path that the mode script is in, which should always be the BOREALIS path.