### PR TITLE
Added phase correction and sample dropping

### DIFF
--- a/utils/signal_processing_options/signalprocessingoptions.cpp
+++ b/utils/signal_processing_options/signalprocessingoptions.cpp
@@ -10,6 +10,8 @@
 SignalProcessingOptions::SignalProcessingOptions() {
   Options::parse_config_file();
 
+  rx_sample_rate = boost::lexical_cast<double>(
+                config_pt.get<std::string>("rx_sample_rate"));
   first_stage_sample_rate = boost::lexical_cast<double>(
                 config_pt.get<std::string>("first_stage_sample_rate"));
   second_stage_sample_rate = boost::lexical_cast<double>(
@@ -45,6 +47,11 @@ SignalProcessingOptions::SignalProcessingOptions() {
   brian_dspend_identity = config_pt.get<std::string>("brian_to_dspend_identity");
   exphan_dsp_identity = config_pt.get<std::string>("exphan_to_dsp_identity");
   dw_dsp_identity = config_pt.get<std::string>("dw_to_dsp_identity");
+}
+
+double SignalProcessingOptions::get_rx_rate() const
+{
+  return rx_sample_rate;
 }
 
 uint32_t SignalProcessingOptions::get_main_antenna_count() const

--- a/utils/signal_processing_options/signalprocessingoptions.hpp
+++ b/utils/signal_processing_options/signalprocessingoptions.hpp
@@ -9,6 +9,7 @@
 class SignalProcessingOptions: public Options {
  public:
   explicit SignalProcessingOptions();
+  double get_rx_rate() const;
   double get_first_stage_sample_rate() const;
   double get_second_stage_sample_rate() const;
   double get_third_stage_sample_rate() const;
@@ -20,12 +21,7 @@ class SignalProcessingOptions: public Options {
   double get_third_stage_filter_transition() const;
   uint32_t get_main_antenna_count() const;
   uint32_t get_interferometer_antenna_count() const;
-/*  std::string get_driver_socket_address() const;
-  std::string get_radar_control_socket_address() const;
-  std::string get_ack_socket_address() const;
-  std::string get_timing_socket_address() const;
-  std::string get_data_write_address() const;
-*/
+
   std::string get_router_address() const;
   std::string get_dsp_radctrl_identity() const;
   std::string get_dsp_driver_identity() const;
@@ -43,6 +39,7 @@ class SignalProcessingOptions: public Options {
  private:
   uint32_t main_antenna_count;
   uint32_t interferometer_antenna_count;
+  double rx_sample_rate;
   double first_stage_sample_rate;
   double second_stage_sample_rate;
   double third_stage_sample_rate;


### PR DESCRIPTION
As part of the modified Frerking filtering translation, the phase term pulled out of filtering needs to be multiplied by the output samples. This pull request addresses this.

This PR also adds in the calculation to drop samples if they may introduce edge effects from using 0 padded values that are used if the filter extends past the length of the input samples.