### PR TITLE
Adding first draft of start up script

### DIFF
--- a/borealisscreenrc
+++ b/borealisscreenrc
@@ -1,27 +1,27 @@
 chdir $BOREALISPATH
-screen -t "Brian" bash -c "python brian/brian.py"
+screen -t "Brian" bash -c "START_BRIAN"
 split
 
 split -v
 focus right
-screen -t "N200 Driver" bash -c "source mode release; n200_driver"
+screen -t "N200 Driver" bash -c "START_N200DRIVER"
 
 split -v
 focus right
-screen -t "Signal Processing" bash -c "source mode release; signal_processing"
+screen -t "Signal Processing" bash -c "START_DSP"
 
 focus down
-screen -t "Data Write" bash -c "python -O data_write/data_write.py"
+screen -t "Data Write" bash -c "START_DATAWRITE"
 
 split -v
 focus right
-screen -t "Experiment Handler" bash -c "python experiment_handler/experiment_handler.py twofsound"
+screen -t "Experiment Handler" bash -c "START_EXPHAN"
 
 split -v
 focus right
-screen -t "Radar Control" bash -c "python -O radar_control/radar_control.py"
+screen -t "Radar Control" bash -c "START_RADCTRL"
 
 split -v
 focus right
-screen -t "Cpu Affinity" bash -c "python -O usrp_drivers/n200/set_affinity.py"
+screen -t "Cpu Affinity" bash -c "START_TIDS"
 

--- a/borealisscreenrc
+++ b/borealisscreenrc
@@ -1,0 +1,27 @@
+chdir $BOREALISPATH
+screen -t "Brian" bash -c "python brian/brian.py"
+split
+
+split -v
+focus right
+screen -t "N200 Driver" bash -c "source mode release; n200_driver"
+
+split -v
+focus right
+screen -t "Signal Processing" bash -c "source mode release; signal_processing"
+
+focus down
+screen -t "Data Write" bash -c "python -O data_write/data_write.py"
+
+split -v
+focus right
+screen -t "Experiment Handler" bash -c "python experiment_handler/experiment_handler.py twofsound"
+
+split -v
+focus right
+screen -t "Radar Control" bash -c "python -O radar_control/radar_control.py"
+
+split -v
+focus right
+screen -t "Cpu Affinity" bash -c "python -O usrp_drivers/n200/set_affinity.py"
+


### PR DESCRIPTION
I just added the screen config that splits windows and starts commands.
We can make this more fancy for starting different modes and control
programs. This lets us use a command line based start up without having to rely on terminator

screen -c borealisscreenrc -S borealis