### PR TITLE
Handling USRP center frequency offsets

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -31,6 +31,7 @@
     "atten_window_time_start" : "10e-6",
     "atten_window_time_end" : "40e-6",
     "tr_window_time" : "60e-6",
+    "usrp_master_clock_rate" : "100e6",
     "first_stage_sample_rate" : "1.0e6",
     "second_stage_sample_rate" : "100.0e3",
     "third_stage_sample_rate" : "3.333e3",

--- a/experiment_prototype/experiment_prototype.py
+++ b/experiment_prototype/experiment_prototype.py
@@ -3,7 +3,7 @@
 """
     experiment_prototype
     ~~~~~~~~~~~~~~~~~~~~
-    This is the base module for all experiments. An experiment will only run if it 
+    This is the base module for all experiments. An experiment will only run if it
     inherits from this class.
 
     :copyright: 2018 SuperDARN Canada
@@ -14,6 +14,7 @@ from __future__ import print_function
 import sys
 import copy
 import os
+import math
 #import pygit2
 
 BOREALISPATH = os.environ['BOREALISPATH']
@@ -38,7 +39,7 @@ SCAN
     Scan by scan interfacing. exp_slice #1 will scan first
     followed by exp_slice #2 and subsequent exp_slice's.
 
-INTTIME 
+INTTIME
     nave by nave interfacing (full integration time of
     one pulse_sequence, then the next). Time/number of pulse_sequences
     dependent on intt and intn in exp_slice. Effectively
@@ -78,9 +79,9 @@ slice_key_set = frozenset(["slice_id", "cpid", "tx_antennas", "rx_main_antennas"
                     "clrfrqrange", "acf", "xcf", "acfint", "wavetype", "seqoffset",
                     "iwavetable", "qwavetable"])
 # TODO add scanboundt?
-"""   
+"""
 **Description of Slice Keys**
-    
+
 slice_id
     The ID of this slice object. An experiment can have multiple slices.
 =======
@@ -91,28 +92,28 @@ cpid
     The ID of the experiment, consistent with existing radar control programs.
 
 tx_antennas
-    The antennas to transmit on, default is all main antennas given max 
+    The antennas to transmit on, default is all main antennas given max
     number from config.
 
 rx_main_antennas
-    The antennas to receive on in main array, default = all antennas 
+    The antennas to receive on in main array, default = all antennas
     given max number from config.
 
 rx_int_antennas
-    The antennas to receive on in interferometer array, default is all 
+    The antennas to receive on in interferometer array, default is all
     antennas given max number from config.
-    
+
 pulse_sequence
-    The pulse sequence timing, given in quantities of mpinc, for example 
+    The pulse sequence timing, given in quantities of mpinc, for example
     normalscan = [0, 14, 22, 24, 27, 31, 42, 43]
-    
+
 mpinc
     multi-pulse increment in us, Defines minimum space between pulses.
-    
+
 pulse_shift
-    Allows phase shifting between pulses, enabling encoding of pulses. Default all 
+    Allows phase shifting between pulses, enabling encoding of pulses. Default all
     zeros for all pulses in pulse_sequence.
-    
+
 pulse_len
     length of pulse in us. Range gate size is also determined by this.
 
@@ -129,24 +130,24 @@ intn
     number of averages to make a single integration, if intt = None.
 
 beam_angle
-    list of beam directions, in degrees off azimuth. Positive is E of N. Array 
-    length = number of beams. Traditionally beams have been 3.24 degrees separated but we 
+    list of beam directions, in degrees off azimuth. Positive is E of N. Array
+    length = number of beams. Traditionally beams have been 3.24 degrees separated but we
     don't refer to them as beam -19.64 degrees, we refer as beam 1, beam 2. Beam 0 will
     be the 0th element in the list, beam 1 will be the 1st, etc. These beam numbers are
-    needed to write the beam_order list. This is like a mapping of beam number (list 
+    needed to write the beam_order list. This is like a mapping of beam number (list
     index) to beam direction off boresight.
 
 beam_order
-    beam numbers written in order of preference, one element in this list corresponds to 
-    one integration period. Can have lists within the list, resulting in multiple beams 
-    running simultaneously in the averaging period, so imaging. A beam number of 0 in 
-    this list gives us the direction of the 0th element in the beam_angle list. It is 
-    up to the writer to ensure their beam pattern makes sense. Typically beam_order is 
-    just in order (scanning W to E or E to W, ie. [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 
-    11, 12, 13, 14, 15]. You can list numbers multiple times in the beam_order list, 
-    for example [0, 1, 1, 2, 1] or use multiple beam numbers in a single 
-    integration time (example [[0, 1], [3, 4]], which would trigger an imaging 
-    integration. When we do imaging we will still have to quantize the directions we 
+    beam numbers written in order of preference, one element in this list corresponds to
+    one integration period. Can have lists within the list, resulting in multiple beams
+    running simultaneously in the averaging period, so imaging. A beam number of 0 in
+    this list gives us the direction of the 0th element in the beam_angle list. It is
+    up to the writer to ensure their beam pattern makes sense. Typically beam_order is
+    just in order (scanning W to E or E to W, ie. [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+    11, 12, 13, 14, 15]. You can list numbers multiple times in the beam_order list,
+    for example [0, 1, 1, 2, 1] or use multiple beam numbers in a single
+    integration time (example [[0, 1], [3, 4]], which would trigger an imaging
+    integration. When we do imaging we will still have to quantize the directions we
     are looking in to certain beam directions.
 
 scanboundflag
@@ -156,14 +157,14 @@ scanbound
     time that is allotted for a scan before a new scan boundary occurs (ms).
 
 clrfrqrange
-    range for clear frequency search, should be a list of length = 2, [min_freq, max_freq] 
+    range for clear frequency search, should be a list of length = 2, [min_freq, max_freq]
     in kHz.
 
 txfreq
     transmit frequency, in kHz. Note if you specify clrfrqrange it won't be used.
 
 rxfreq
-    receive frequency, in kHz. Note if you specify clrfrqrange or txfreq it won't be used. Only 
+    receive frequency, in kHz. Note if you specify clrfrqrange or txfreq it won't be used. Only
     necessary to specify if you want a receive-only slice.
 
 acf
@@ -176,65 +177,65 @@ acfint
     flag for interferometer autocorrelation data. The default is True.
 
 wavetype
-    string for wavetype. The default is SINE. Any other wavetypes not currently supported but 
+    string for wavetype. The default is SINE. Any other wavetypes not currently supported but
     possible to add in at later date.
 
 iwavetable
-    a list of numeric values to sample from. The default is None. Not currently supported 
+    a list of numeric values to sample from. The default is None. Not currently supported
     but could be set up (with caution) for non-SINE.
 
 qwavetable
-    a list of numeric values to sample from. The default is None. Not currently supported 
+    a list of numeric values to sample from. The default is None. Not currently supported
     but could be set up (with caution) for non-SINE.
 
 seqoffset
-    offset in us that this slice's sequence will begin at, after the start of the sequence. 
-    This is intended for PULSE interfacing, when you want multiple slice's pulses in one sequence 
+    offset in us that this slice's sequence will begin at, after the start of the sequence.
+    This is intended for PULSE interfacing, when you want multiple slice's pulses in one sequence
     you can offset one slice's sequence from the other by a certain time value so as to not run both
     frequencies in the same pulse, etc.
 
-Should add: 
+Should add:
 
-scanboundt : time past the hour to start a scan at ?  
+scanboundt : time past the hour to start a scan at ?
 """
 
 hidden_key_set = frozenset(['rxonly', 'clrfrqflag'])
 """
-These are used by the build_scans method (called from the experiment_handler every 
-time the experiment is run). If set by the user, the values will be overwritten and 
-therefore ignored. 
+These are used by the build_scans method (called from the experiment_handler every
+time the experiment is run). If set by the user, the values will be overwritten and
+therefore ignored.
 """
 
 class ExperimentPrototype(object):
-    """ 
+    """
     The base class for all experiments.
-    
-    A prototype experiment class composed of metadata, including experiment slices (exp_slice) 
-    which are dictionaries of radar parameters. Basic, traditional experiments will be composed of 
-    a single slice. More complicated experiments will be composed of multiple slices that 
+
+    A prototype experiment class composed of metadata, including experiment slices (exp_slice)
+    which are dictionaries of radar parameters. Basic, traditional experiments will be composed of
+    a single slice. More complicated experiments will be composed of multiple slices that
     interface in one of four pre-determined ways, as described under interface_types.
-    
+
     This class is used via inheritance to create experiments.
-    
-    Some variables shouldn't be changed by the experiment, and their properties do not have setters. 
-    Some variables can be changed in the init of your experiment, and can also be modified 
+
+    Some variables shouldn't be changed by the experiment, and their properties do not have setters.
+    Some variables can be changed in the init of your experiment, and can also be modified
     in-experiment by the class method 'update' in your experiment class. These variables have been
     given property setters.
-    
-    The following are the user-modifiable attributes of the ExperimentPrototype that are 
+
+    The following are the user-modifiable attributes of the ExperimentPrototype that are
     used to make an experiment:
-    
+
     * xcf: boolean for cross-correlation data
     * acf: boolean for auto-correlation data on main array
     * acfint: boolean for auto-correlation data on interferometer array
-    * txctrfreq: transmit centre frequency (that RF chain is tuned to) - modifying 
+    * txctrfreq: transmit centre frequency (that RF chain is tuned to) - modifying
       requires tuning time.
     * rxctrfreq: receive centre frequency - modifying requires tuning time.
-    * slice_dict: modifiable only using the add_slice, edit_slice, and del_slice 
+    * slice_dict: modifiable only using the add_slice, edit_slice, and del_slice
       methods.
-    * interface: modifiable using the add_slice, edit_slice, and del_slice 
+    * interface: modifiable using the add_slice, edit_slice, and del_slice
       methods, or by updating the interface dict directly.
-      
+
     """
 
     __slice_keys = slice_key_set
@@ -253,6 +254,7 @@ class ExperimentPrototype(object):
             errmsg = 'CPID must be a unique int'
             raise ExperimentException(errmsg)
 
+        self.__options = ExperimentOptions()
         self.__experiment_name = self.__class__.__name__  # TODO use this to check the cpid is correct using pygit2, or __class__.__module__ for module name
 
         self.__cpid = cpid
@@ -262,11 +264,12 @@ class ExperimentPrototype(object):
         self.__new_slice_id = 0
 
         # Centre frequencies can be specified in your experiment class using the setter. TODO: make modifiable (with warning that it takes time. Get time estimate for this.
-        self.__txctrfreq = 13000  # in kHz.
-        self.__rxctrfreq = 13000  # in kHz.
+        self.txctrfreq = 12000  # in kHz.
+        self.rxctrfreq = 12000  # in kHz.
 
+        print(self.txctrfreq)
         # Load the config, hardware, and restricted frequency data
-        self.__options = ExperimentOptions()
+
         self.__txrate = self.__options.tx_sample_rate  # sampling rate, samples per sec, Hz.
         self.__rxrate = self.__options.rx_sample_rate  # sampling rate for rx in samples per sec
         # Transmitting is possible in the range of txctrfreq +/- (txrate/2) because we have iq data
@@ -303,7 +306,7 @@ class ExperimentPrototype(object):
     def cpid(self):
         """
         This experiment's CPID (control program ID, a term that comes from ROS).
-        
+
         The CPID is read-only once established in instantiation.
         """
 
@@ -312,8 +315,8 @@ class ExperimentPrototype(object):
     @property
     def num_slices(self):
         """
-        The number of slices currently in the experiment. 
-        
+        The number of slices currently in the experiment.
+
         Will change after methods add_slice or del_slice are called.
         """
 
@@ -322,9 +325,9 @@ class ExperimentPrototype(object):
     @property
     def slice_keys(self):
         """
-        The list of slice keys available. 
-        
-        This cannot be updated. These are the keys in the current ExperimentPrototype 
+        The list of slice keys available.
+
+        This cannot be updated. These are the keys in the current ExperimentPrototype
         slice_keys dictionary (the parameters available for slices).
         """
 
@@ -333,13 +336,13 @@ class ExperimentPrototype(object):
     @property
     def slice_dict(self):
         """
-        The dictionary of slices. 
-        
-        The slice dictionary can be updated in add_slice, edit_slice, and del_slice. The slice 
+        The dictionary of slices.
+
+        The slice dictionary can be updated in add_slice, edit_slice, and del_slice. The slice
         dictionary is a dictionary of dictionaries that looks like:
-        
-        { slice_id1 : {slice_key1 : x, slice_key2 : y, ...}, 
-        slice_id2 : {slice_key1 : x, slice_key2 : y, ...}, 
+
+        { slice_id1 : {slice_key1 : x, slice_key2 : y, ...},
+        slice_id2 : {slice_key1 : x, slice_key2 : y, ...},
         ...}
         """
 
@@ -349,7 +352,7 @@ class ExperimentPrototype(object):
     def new_slice_id(self):
         """
         The next unique slice id that is available to this instance of the experiment.
-        
+
         This gets incremented after each time it is called to ensure it returns
         a unique ID each time.
         """
@@ -360,8 +363,8 @@ class ExperimentPrototype(object):
     @property
     def slice_ids(self):
         """
-        The list of slice ids that are currently available in this experiment. 
-        
+        The list of slice ids that are currently available in this experiment.
+
         This can change when add_slice, edit_slice, and del_slice are called.
         """
 
@@ -370,9 +373,9 @@ class ExperimentPrototype(object):
     @property
     def options(self):
         """
-        The config options for running this experiment. 
-        
-        These cannot be set or removed, but are specified in the config.ini, hdw.dat, and 
+        The config options for running this experiment.
+
+        These cannot be set or removed, but are specified in the config.ini, hdw.dat, and
         restrict.dat files.
         """
 
@@ -382,7 +385,7 @@ class ExperimentPrototype(object):
     def xcf(self):
         """
         The default cross-correlation flag boolean.
-        
+
         This provides the default for slices where this key isn't specified.
         """
 
@@ -392,7 +395,7 @@ class ExperimentPrototype(object):
     def xcf(self, value):
         """
         Set the cross-correlation flag default for new slices.
-        
+
         :param value: boolean for cross-correlation processing flag.
         """
 
@@ -404,8 +407,8 @@ class ExperimentPrototype(object):
     @property
     def acf(self):
         """
-        The default auto-correlation flag boolean. 
-        
+        The default auto-correlation flag boolean.
+
         This provides the default for slices where this key isn't specified.
         """
 
@@ -415,7 +418,7 @@ class ExperimentPrototype(object):
     def acf(self, value):
         """
         Set the auto-correlation flag default for new slices.
-        
+
         :param value: boolean for auto-correlation processing flag.
         """
 
@@ -428,7 +431,7 @@ class ExperimentPrototype(object):
     def acfint(self):
         """
         The default interferometer autocorrelation boolean.
-        
+
         This provides the default for slices where this key isn't specified.
         """
 
@@ -438,7 +441,7 @@ class ExperimentPrototype(object):
     def acfint(self, value):
         """
         Set the interferometer autocorrelation flag default for new slices.
-        
+
         :param value: boolean for interferometer autocorrelation processing flag.
         """
 
@@ -451,7 +454,7 @@ class ExperimentPrototype(object):
     def txrate(self):
         """
         The transmission sample rate to the DAC (Hz).
-        
+
         This is not modifiable and comes from the config options.
         """
 
@@ -461,7 +464,7 @@ class ExperimentPrototype(object):
     def txctrfreq(self):
         """
         The transmission centre frequency that USRP is tuned to (Hz).
-        
+
         If you would like to change this value, note that it will take tuning time.
         """
         return self.__txctrfreq
@@ -469,15 +472,20 @@ class ExperimentPrototype(object):
     @txctrfreq.setter
     def txctrfreq(self, value):
         """
-        Set the transmission centre frequency that USRP is tuned to. 
-        
-        This will take tuning time, use with caution.     
-            
+        Set the transmission centre frequency that USRP is tuned to.
+
+        This will take tuning time, use with caution. The USRP center frequency can only be tuned
+        in steps of the master clock rate / 2^32. We determine the closest value to the desired
+        center frequency and adjust to that.
+
         :param value: int for transmission centre frequency to tune USRP to (Hz).
         """
         # TODO review if this should be modifiable, definitely takes tuning time.
         if isinstance(value, int):
-            self.__txctrfreq = value # TODO return actual value tuned to.
+            # convert from kHz to Hz to get correct clock divider. Return the result back in kHz.
+            clock_multiples = self.options.usrp_master_clock_rate/2**32
+            clock_divider = math.ceil(value*1e3/clock_multiples)
+            self.__txctrfreq = (clock_divider * clock_multiples)/1e3 # TODO return actual value tuned to.
         else:
             pass  # TODO errors / log no change
 
@@ -485,7 +493,7 @@ class ExperimentPrototype(object):
     def tx_maxfreq(self):
         """
         The maximum transmit frequency.
-        
+
         This is the maximum tx frequency possible in this experiment (either maximum in our license
         or maximum given by the centre frequency and sampling rate).
         """
@@ -500,7 +508,7 @@ class ExperimentPrototype(object):
     def tx_minfreq(self):
         """
         The minimum transmit frequency.
-        
+
         This is the minimum tx frequency possible in this experiment (either minimum in our license
         or minimum given by the centre frequency and sampling rate).
         """
@@ -515,7 +523,7 @@ class ExperimentPrototype(object):
     def rxctrfreq(self):
         """
         The receive centre frequency that USRP is tuned to (Hz).
-        
+
         If you would like to change this, note that it will take tuning time.
         """
         return self.__rxctrfreq
@@ -523,23 +531,28 @@ class ExperimentPrototype(object):
     @rxctrfreq.setter
     def rxctrfreq(self, value):
         """
-        Set the receive centre frequency that USRP is tuned to (Hz). 
-        
-        This will take tuning time, use with caution.  
-        
-        :param value: int for receive centre frequency to tune USRP to (Hz).
+        Set the receive centre frequency that USRP is tuned to (Hz).
+
+        This will take tuning time, use with caution.
+
+        :param value: int for receive centre frequency to tune USRP to (Hz). The USRP center
+        frequency can only be tuned in steps of the master clock rate / 2^32. We determine the
+        closest value to the desired center frequency and adjust to that.
         """
         # TODO review if this should be modifiable, definitely takes tuning time.
         if isinstance(value, int):
-            self.__rxctrfreq = value  # TODO return actual tuned freq.
+            # convert from kHz to Hz to get correct clock divider. Return the result back in kHz.
+            clock_multiples = self.options.usrp_master_clock_rate/2**32
+            clock_divider = math.ceil(value*1e3/clock_multiples)
+            self.__rxctrfreq = (clock_divider * clock_multiples)/1e3   # TODO return actual tuned freq.
         else:
             pass  # TODO errors
 
     @property
     def rxrate(self):
         """
-        The receive sampling rate in samples per sec. 
-        
+        The receive sampling rate in samples per sec.
+
         This comes from the config file and cannot be changed in the experiment.
         """
         return self.__rxrate
@@ -548,8 +561,8 @@ class ExperimentPrototype(object):
     def rx_maxfreq(self):
         """
         The maximum receive frequency.
-        
-        This is the maximum tx frequency possible in this experiment (maximum given by the centre 
+
+        This is the maximum tx frequency possible in this experiment (maximum given by the centre
         frequency and sampling rate), as license doesn't matter for receiving.
         """
         max_freq = self.rxctrfreq * 1000 + (self.rxrate/2.0)
@@ -558,9 +571,9 @@ class ExperimentPrototype(object):
     @property
     def rx_minfreq(self):
         """
-        The minimum receive frequency. 
-        
-        This is the minimum rx frequency possible in this experiment (minimum given by the centre 
+        The minimum receive frequency.
+
+        This is the minimum rx frequency possible in this experiment (minimum given by the centre
         frequency and sampling rate) - license doesn't restrict receiving.
         """
         min_freq = self.rxctrfreq * 1000 - (self.rxrate/2.0)
@@ -572,17 +585,17 @@ class ExperimentPrototype(object):
     @property
     def interface(self):
         """
-        The dictionary of interfacing for the experiment slices.  
-        
-        Interfacing should be set up for any slice when it gets added, ie. in add_slice, 
+        The dictionary of interfacing for the experiment slices.
+
+        Interfacing should be set up for any slice when it gets added, ie. in add_slice,
         except for the first slice added. The dictionary of interfacing is setup as:
-        
-        [(slice_id1, slice_id2) : INTERFACING_TYPE, 
-        (slice_id1, slice_id3) : INTERFACING_TYPE, 
-        ...] 
-        
-        for all current slice_ids. 
-        
+
+        [(slice_id1, slice_id2) : INTERFACING_TYPE,
+        (slice_id1, slice_id3) : INTERFACING_TYPE,
+        ...]
+
+        for all current slice_ids.
+
         """
         return self._interface
 
@@ -590,7 +603,7 @@ class ExperimentPrototype(object):
     def slice_id_scan_lists(self):
         """
         The list of scan slice ids (a list of lists of slice_ids, organized by scan).
-        
+
         This cannot be modified by the user.
         """
         return self.__slice_id_scan_lists
@@ -598,8 +611,8 @@ class ExperimentPrototype(object):
     @property
     def scan_objects(self):
         """
-        The list of instances of class Scan for use in radar_control. 
-        
+        The list of instances of class Scan for use in radar_control.
+
         These cannot be modified by the user, but are created using the slice dictionary.
         """
         return self.__scan_objects
@@ -607,9 +620,9 @@ class ExperimentPrototype(object):
     def slice_beam_directions_mapping(self, slice_id):
         """
         A mapping of the beam directions in the given slice id.
-        
+
         :param slice_id: id of the slice to get beam directions for.
-        :returns mapping: enumeration mapping dictionary of beam number to beam 
+        :returns mapping: enumeration mapping dictionary of beam number to beam
          direction(s) in degrees off boresight.
         """
         if slice_id not in self.slice_ids:
@@ -623,12 +636,12 @@ class ExperimentPrototype(object):
     def add_slice(self, exp_slice, interfacing_dict=None):
         """
         Add a slice to the experiment.
-        
+
         :param exp_slice: a slice (dictionary of slice_keys) to add to the experiment.
-        :param interfacing_dict: dictionary of type {slice_id : INTERFACING , ... } that 
-         defines how this slice interacts with all the other slices currently in the 
+        :param interfacing_dict: dictionary of type {slice_id : INTERFACING , ... } that
+         defines how this slice interacts with all the other slices currently in the
          experiment.
-        :raises: ExperimentException if slice is not a dictionary or if there are 
+        :raises: ExperimentException if slice is not a dictionary or if there are
          errors in setup_slice.
         :return: the slice_id of the new slice that was just added.
         """
@@ -679,7 +692,7 @@ class ExperimentPrototype(object):
     def del_slice(self, remove_slice_id):
         """
         Remove a slice from the experiment.
-        
+
         :param remove_slice_id: the id of the slice you'd like to remove.
         :raises: exception if remove_slice_id does not exist in the slice dictionary.
         """
@@ -696,18 +709,18 @@ class ExperimentPrototype(object):
 
     def edit_slice(self, edit_slice_id, **kwargs):
         """
-        Edit a slice. 
-        
-        A quick way to edit a slice. In reality this is actually adding a new slice and 
+        Edit a slice.
+
+        A quick way to edit a slice. In reality this is actually adding a new slice and
         deleting the old one. Useful for quick changes. Note that using this function
         will remove the slice_id that you are changing and will give it a new id. It will
-        account for this in the interfacing dictionary though. 
-        
+        account for this in the interfacing dictionary though.
+
         :param edit_slice_id: the slice id of the slice to be edited.
-        :param kwargs: dictionary of slice parameter to slice value that you want to 
+        :param kwargs: dictionary of slice parameter to slice value that you want to
          change.
         :returns new_slice_id: the new slice id of the edited slice.
-        :raises: exceptions if the edit_slice_id does not exist in slice dictionary or 
+        :raises: exceptions if the edit_slice_id does not exist in slice dictionary or
          the params or values do not make sense.
         """
 
@@ -755,12 +768,12 @@ class ExperimentPrototype(object):
         return represent
 
     def build_scans(self):
-        """ 
-        Build the scan information, which means creating the Scan, AveragingPeriod, and 
+        """
+        Build the scan information, which means creating the Scan, AveragingPeriod, and
         Sequence instances needed to run this experiment.
-        
-        Will be run by experiment handler, to build iterable objects for radar_control to 
-        use. Creates scan_objects and slice_id_scan_lists in the experiment for 
+
+        Will be run by experiment handler, to build iterable objects for radar_control to
+        use. Creates scan_objects and slice_id_scan_lists in the experiment for
         identifying which slices are in the scans.
         """
 
@@ -828,15 +841,15 @@ class ExperimentPrototype(object):
         # which would allow you to determine which interfacing to pull out.
         """
         Organize the slice_ids by scan.
-        
-        Take my own interfacing and get info on how many scans and which slices make which 
-        scans. Return a list of lists where each inner list contains the slices that 
-        are in an averagingperiod that is inside this scan. ie. len(nested_slice_list) 
-        = # of averagingperiods in this scan, len(nested_slice_list[0]) = # of slices 
+
+        Take my own interfacing and get info on how many scans and which slices make which
+        scans. Return a list of lists where each inner list contains the slices that
+        are in an averagingperiod that is inside this scan. ie. len(nested_slice_list)
+        = # of averagingperiods in this scan, len(nested_slice_list[0]) = # of slices
         in the first averagingperiod, etc.
-        
-        :return list of lists. The list has one element per scan. Each element is a list 
-        of slice_ids signifying which slices are combined inside that scan. The list 
+
+        :return list of lists. The list has one element per scan. Each element is a list
+        of slice_ids signifying which slices are combined inside that scan. The list
         returned could be of length 1, meaning only one scan is present in the experiment.
         """
         scan_combos = []
@@ -855,13 +868,13 @@ class ExperimentPrototype(object):
     def check_slice_minimum_requirements(self, exp_slice):
         """
         Check the required slice keys.
-        
+
         Check for the minimum requirements of the slice. The following keys are always required:
-        "pulse_sequence", "mpinc", "pulse_len", "nrang", "frang", (one of "intt" or "intn"), 
+        "pulse_sequence", "mpinc", "pulse_len", "nrang", "frang", (one of "intt" or "intn"),
         "beam_angle", and "beam_order". This function may modify the values in this slice dictionary
         to ensure that it is able to be run and that the values make sense.
-        
-        :param exp_slice: slice to check. 
+
+        :param exp_slice: slice to check.
         """
 
         # TODO: add checks for values that make sense, not just check for types
@@ -941,7 +954,7 @@ class ExperimentPrototype(object):
                 if isinstance(element, int):
                     element = float(element)
         except AssertionError:
-            errmsg = """Slice must specify beam_angle that must be a list of numbers (ints or 
+            errmsg = """Slice must specify beam_angle that must be a list of numbers (ints or
                 floats) which are angles of degrees off boresight (positive E of N)"""
             raise ExperimentException(errmsg, exp_slice)
 
@@ -957,7 +970,7 @@ class ExperimentPrototype(object):
                 else:
                     assert element < len(exp_slice['beam_angle'])
         except AssertionError:
-            errmsg = """Slice must specify beam_order that must be a list of ints or lists (of ints) 
+            errmsg = """Slice must specify beam_order that must be a list of ints or lists (of ints)
                      corresponding to the order of the angles in the beam_angle list."""
             raise ExperimentException(errmsg, exp_slice)
 
@@ -965,12 +978,12 @@ class ExperimentPrototype(object):
     def set_slice_identifiers(exp_slice):
         """
         Set the hidden slice keys to determine how to run the slice.
-        
-        This function sets up internal identifier flags 'clrfrqflag' and 'rxonly' in the slice so 
-        that we know how to properly set up the slice and know which keys in the slice must be 
-        specified and which are unnecessary. If these keys are ever written by the user, they will 
+
+        This function sets up internal identifier flags 'clrfrqflag' and 'rxonly' in the slice so
+        that we know how to properly set up the slice and know which keys in the slice must be
+        specified and which are unnecessary. If these keys are ever written by the user, they will
         be rewritten here.
-        
+
         :param exp_slice: slice in which to set identifiers
         """
 
@@ -1009,13 +1022,13 @@ class ExperimentPrototype(object):
 
     def check_slice_specific_requirements(self, exp_slice):
         """
-        Set the specific slice requirements depending. 
-        
-        Check the requirements for the specific slice type as identified by the 
-        identifiers rxonly and clrfrqflag. The keys that need to be checked depending 
-        on these identifiers are "txfreq", "rxfreq", and "clrfrqrange". This function 
+        Set the specific slice requirements depending.
+
+        Check the requirements for the specific slice type as identified by the
+        identifiers rxonly and clrfrqflag. The keys that need to be checked depending
+        on these identifiers are "txfreq", "rxfreq", and "clrfrqrange". This function
         may modify these keys.
-        
+
         :param exp_slice: the slice to check, before adding to the experiment.
         """
         if exp_slice['clrfrqflag']:  # TX and RX mode with clear frequency search.
@@ -1035,8 +1048,8 @@ class ExperimentPrototype(object):
                 assert (exp_slice['clrfrqrange'][1] * 1000) < self.rx_maxfreq
                 assert (exp_slice['clrfrqrange'][0] * 1000) > self.rx_minfreq
             except AssertionError:
-                errmsg = """clrfrqrange must be between min and max tx frequencies {} and rx 
-                            frequencies {} according to license and/or centre frequencies / sampling 
+                errmsg = """clrfrqrange must be between min and max tx frequencies {} and rx
+                            frequencies {} according to license and/or centre frequencies / sampling
                             rates, and must have lower frequency first.
                             """.format((self.tx_minfreq, self.tx_maxfreq),
                                        (self.rx_minfreq, self.rx_maxfreq))
@@ -1097,7 +1110,7 @@ class ExperimentPrototype(object):
                 assert (exp_slice['rxfreq'] * 1000) > self.rx_minfreq
             except AssertionError:
                 errmsg = """rxfreq must be a number (kHz) between rx min and max frequencies {} for
-                            the radar license and be within range given centre frequency and 
+                            the radar license and be within range given centre frequency and
                             sampling rate.""".format((self.rx_minfreq, self.rx_maxfreq))
                 raise ExperimentException(errmsg)
 
@@ -1128,7 +1141,7 @@ class ExperimentPrototype(object):
     def set_slice_defaults(self, exp_slice):
         """
         Set up defaults in case of some parameters being left blank.
-        
+
         :param exp_slice: slice to set defaults of
         :returns slice_with_defaults: updated slice
         """
@@ -1185,12 +1198,12 @@ class ExperimentPrototype(object):
     def setup_slice(self, exp_slice):
         """
         Check slice for errors and set defaults of optional keys.
-        
+
         Before adding the slice, ensure that the internal parameters are set, remove unnecessary
         keys and check values of keys that are needed, and set defaults of keys that are optional.
-        
+
         The following are always able to be defaulted, so are optional:
-        "tx_antennas", "rx_main_antennas", "rx_int_antennas", "pulse_shift", "scanboundflag", 
+        "tx_antennas", "rx_main_antennas", "rx_int_antennas", "pulse_shift", "scanboundflag",
         "scanbound", "acf", "xcf", "acfint", "wavetype", "seqoffset"
 
 
@@ -1200,8 +1213,8 @@ class ExperimentPrototype(object):
         "beam_order"
 
         The following are required depending on slice type:
-        "txfreq", "rxfreq", "clrfrqrange" 
-        
+        "txfreq", "rxfreq", "clrfrqrange"
+
         :param: exp_slice: a slice to setup
         :return: complete_slice : a checked slice with all defaults
         """
@@ -1235,7 +1248,7 @@ class ExperimentPrototype(object):
     def self_check(self):
         """
         Check that the values in this experiment are valid.
-        
+
         Checks all slices.
         """
 
@@ -1270,11 +1283,11 @@ class ExperimentPrototype(object):
     def check_slice(self, exp_slice):
         """
         Check the slice for errors.
-        
-        This is the first test of the dictionary in the experiment done to ensure values in this 
-        slice make sense. This is a self-check to ensure the parameters (for example, txfreq, 
-        antennas) are appropriate. All fields should be full at this time (whether filled by the 
-        user or given default values in set_slice_defaults). This was built to be useable at 
+
+        This is the first test of the dictionary in the experiment done to ensure values in this
+        slice make sense. This is a self-check to ensure the parameters (for example, txfreq,
+        antennas) are appropriate. All fields should be full at this time (whether filled by the
+        user or given default values in set_slice_defaults). This was built to be useable at
         any time after setup.
         :param: exp_slice: a slice to check
         :raise: ExperimentException: When necessary parameters do not exist or = None (would have

--- a/experiment_prototype/experiment_prototype.py
+++ b/experiment_prototype/experiment_prototype.py
@@ -264,8 +264,8 @@ class ExperimentPrototype(object):
         self.__new_slice_id = 0
 
         # Centre frequencies can be specified in your experiment class using the setter. TODO: make modifiable (with warning that it takes time. Get time estimate for this.
-        self.txctrfreq = 12000  # in kHz.
-        self.rxctrfreq = 12000  # in kHz.
+        self.__txctrfreq = self.txctrfreq = 12000  # in kHz.
+        self.__rxctrfreq = self.rxctrfreq = 12000  # in kHz.
 
         print(self.txctrfreq)
         # Load the config, hardware, and restricted frequency data

--- a/utils/experiment_options/experimentoptions.py
+++ b/utils/experiment_options/experimentoptions.py
@@ -3,7 +3,7 @@
 # Copyright 2017 SuperDARN Canada
 
 """
-To load the config options to be used by the experiment and radar_control blocks. 
+To load the config options to be used by the experiment and radar_control blocks.
 Config data comes from the config.ini file, the hdw.dat file, and the restrict.dat file.
 """
 
@@ -56,6 +56,7 @@ class ExperimentOptions:
             self.tr_window_time = float(config['tr_window_time'])  # s
             self.atten_window_time_start = float(config['atten_window_time_start'])  # s
             self.atten_window_time_end = float(config['atten_window_time_end'])  # s
+            self.usrp_master_clock_rate = float(config['usrp_master_clock_rate']) # Hz
             self.router_address = config['router_address']
             self.radctrl_to_exphan_identity = str(config["radctrl_to_exphan_identity"])
             self.radctrl_to_dsp_identity = str(config["radctrl_to_dsp_identity"])


### PR DESCRIPTION
The USRP can only be tuned in steps of the master clock rate / 2^32.
This code adjusts for that in the experiment prototype so that samples
are correct generated at the right frequency.