### PR TITLE
Fix in case tx rates and rx rates differ

### DIFF
--- a/experiment_prototype/scan_classes/sequences.py
+++ b/experiment_prototype/scan_classes/sequences.py
@@ -57,7 +57,7 @@ class Sequence(ScanClassBase):
         the sstime.
     first_rx_sample_time
         The location of the first sample for the RX data, in time, from the start of the TX data.
-        This will be calculated as the time at centre sample of the first pulse.
+        This will be calculated as the time at centre sample of the first pulse. In seconds.
     blanks
         A list of sample indices that should not be used for acfs because they were samples
         taken when transmitting.

--- a/radar_control/radar_control.py
+++ b/radar_control/radar_control.py
@@ -141,7 +141,7 @@ def send_metadata(packet, radctrl_to_dsp, dsp_radctrl_iden, radctrl_to_brian,
         transmissions.
         :param first_rx_sample_time: Time between start of tx data and where the first RX sample
         should occur in the output data. This is equal to the time to the centre of the
-        first pulse.
+        first pulse. In seconds.
         :param main_antenna_count: number of main array antennas, from the config file.
 
     """

--- a/radar_control/radar_control.py
+++ b/radar_control/radar_control.py
@@ -87,7 +87,6 @@ def data_to_driver(driverpacket, radctrl_to_driver, driver_to_radctrl_iden, ante
     driverpacket.sequence_num = seqnum
     driverpacket.numberofreceivesamples = numberofreceivesamples
 
-
     if repeat:
         # antennas empty
         # samples empty
@@ -124,7 +123,7 @@ def data_to_driver(driverpacket, radctrl_to_driver, driver_to_radctrl_iden, ante
 
 def send_metadata(packet, radctrl_to_dsp, dsp_radctrl_iden, radctrl_to_brian,
                    brian_radctrl_iden, seqnum, slice_ids,
-                   slice_dict, beam_dict, sequence_time, first_rx_sample, main_antenna_count):
+                   slice_dict, beam_dict, sequence_time, first_rx_sample_time, main_antenna_count):
     """ Place data in the receiver packet and send it via zeromq to the signal processing unit.
         :param packet: the signal processing packet of the protobuf sigprocpacket type.
         :param radctrl_to_dsp: The sender socket for sending data to dsp
@@ -140,9 +139,9 @@ def send_metadata(packet, radctrl_to_dsp, dsp_radctrl_iden, radctrl_to_brian,
         :param beam_dict: The dictionary containing beam directions for each slice.
         :param sequence_time: entire duration of sequence, including receive time after all
         transmissions.
-        :param first_rx_sample: The sample offset from the start of the first pulse of TX samples
-        sent to the driver, where the first RX sample should occur in the output data. This is
-        equal to the sample offset to the centre of the first pulse.
+        :param first_rx_sample_time: Time between start of tx data and where the first RX sample
+        should occur in the output data. This is equal to the time to the centre of the
+        first pulse.
         :param main_antenna_count: number of main array antennas, from the config file.
 
     """
@@ -152,7 +151,7 @@ def send_metadata(packet, radctrl_to_dsp, dsp_radctrl_iden, radctrl_to_brian,
     packet.Clear()
     packet.sequence_time = sequence_time
     packet.sequence_num = seqnum
-    packet.first_rx_sample_from_tx_start = first_rx_sample
+    packet.offset_to_first_rx_sample = first_rx_sample_time
     for num, slice_id in enumerate(slice_ids):
         chan_add = packet.rxchannel.add()
         chan_add.slice_id = slice_id
@@ -552,7 +551,8 @@ def radar():
                                            seqnum_start + nave,
                                            sequence.slice_ids, experiment.slice_dict,
                                            beam_phase_dict, sequence.seqtime,
-                                           sequence.first_rx_sample, options.main_antenna_count)
+                                           sequence.first_rx_sample_time,
+                                          options.main_antenna_count)
 
                             # beam_phase_dict is slice_id : list of beamdirs, where beamdir = list
                             # of antenna phase offsets for all antennas for that direction ordered

--- a/rx_signal_processing/rx_dsp_chain.cu
+++ b/rx_signal_processing/rx_dsp_chain.cu
@@ -247,8 +247,9 @@ int main(int argc, char **argv){
 
     DEBUG_MSG("   Total samples in data message: " << total_samples);
 
+    auto offset_to_first_rx_sample = uint32_t(sp_packet.offset_to_first_rx_sample() * rx_rate);
     dp->allocate_and_copy_rf_samples(total_antennas, samples_needed, extra_samples,
-                                sp_packet.first_rx_sample_from_tx_start(),
+                                offset_to_first_rx_sample,
                                 rx_metadata.initialization_time(),
                                 rx_metadata.sequence_start_time(),
                                 rx_metadata.ringbuffer_size(), first_stage_dm_rate,

--- a/sample_building/sample_building.py
+++ b/sample_building/sample_building.py
@@ -595,15 +595,17 @@ def create_debug_sequence_samples(txrate, txctrfreq, list_of_pulse_dicts,
     return write_dict
 
 
-def calculate_first_rx_sample_index(first_pulse_num_samples_with_tr):
+def calculate_first_rx_sample_time(first_pulse_num_samples_with_tr, txrate):
     """
     The first rx sample time is in the centre of the first pulse, so find the sample number of
     that time in the TX data so we can align the samples and offset appropriately in the RX
     decimated data. Assumes window time for TR is the same at front and end of actual non-zero
     samples.
     :param first_pulse_num_samples_with_tr: number of samples in the first pulse.
-    :return: first_rx_sample_index, sample index of centre of first pulse.
+    :param txrate: The transmitting sample rate.
+    :return: first_rx_sample_time, time to centre of first pulse.
     """
 
     first_rx_sample_index = int(first_pulse_num_samples_with_tr/2)
-    return first_rx_sample_index
+    first_rx_sample_time = float(first_rx_sample_index)/txrate
+    return first_rx_sample_time

--- a/sample_building/sample_building.py
+++ b/sample_building/sample_building.py
@@ -602,7 +602,7 @@ def calculate_first_rx_sample_time(first_pulse_num_samples_with_tr, txrate):
     decimated data. Assumes window time for TR is the same at front and end of actual non-zero
     samples.
     :param first_pulse_num_samples_with_tr: number of samples in the first pulse.
-    :param txrate: The transmitting sample rate.
+    :param txrate: The transmitting sample rate, in Hz.
     :return: first_rx_sample_time, time to centre of first pulse.
     """
 

--- a/utils/protobuf/sigprocpacket.proto
+++ b/utils/protobuf/sigprocpacket.proto
@@ -7,7 +7,7 @@ message SigProcPacket {
     uint32 sequence_num = 2;
     double kerneltime = 3;
     float sequence_time = 4;
-    uint32 first_rx_sample_from_tx_start = 5;
+    uint32 offset_to_first_rx_sample = 5;
 
     message RXChan {
         uint32 slice_id = 1;


### PR DESCRIPTION
sending first_rx_sample_time instead of sample index in case rx rate
differs from tx rate.