### PR TITLE
Adding in code for intf offset

### DIFF
--- a/radar_control/radar_control.py
+++ b/radar_control/radar_control.py
@@ -579,7 +579,7 @@ def radar():
                                                           options.interferometer_antenna_count,
                                                           options.main_antenna_spacing,
                                                           options.interferometer_antenna_spacing,
-                                                          receive_freq)
+                                                          options.intf_offset, receive_freq)
 
                         beam_phase_dict_list.append(beam_phase_dict)
 

--- a/sample_building/sample_building.py
+++ b/sample_building/sample_building.py
@@ -69,7 +69,6 @@ def get_phshift(beamdir, freq, antenna, pulse_shift, num_antennas, antenna_spaci
     beamrad = math.pi * float(beamdir) / 180.0
 
     # Pointing to right of boresight, use point in middle (hypothetically antenna 7.5) as phshift=0
-    #   so all channels have a non-zero phase shift
     phshift = 2 * math.pi * freq * (((num_antennas-1)/2.0 - antenna) * \
         antenna_spacing + centre_offset) * math.cos(math.pi / 2.0 - beamrad) \
         / speed_of_light

--- a/utils/experiment_options/experimentoptions.py
+++ b/utils/experiment_options/experimentoptions.py
@@ -144,10 +144,10 @@ class ExperimentOptions:
         self._analog_rx_attenuator = params[9]  # dB
         self._tdiff = params[10] # ns
         self._phase_sign = params[11]
-        self._intf_offset = [float(params[12]), float(params[13]), float(params[14])]  #
+        self._intf_offset = [float(params[12]), float(params[13]), float(params[14])]  
         # interferometer offset from
         # midpoint of main, metres [x, y, z] where x is along line of antennas, y is along array
-        # normal and z is altitude difference.
+        # normal and z is altitude difference, in m.
         self._analog_rx_rise = params[15]  # us
         self._analog_atten_stages = params[16]  # number of stages
         self._max_range_gates = params[17]


### PR DESCRIPTION
To be applied during beamforming. The centre offset along the array is
now accounted for in the interferometer beamforming (intf is beamformed
with the same phases as antennas 6,7,8,9 in main array in the Saskatoon
configuration). This did not work for all cases (sites) previously.

There was also a bug in how the centre was being calculated in the
get_phshift function, now fixed.