### PR TITLE
Eliminating zmq assertion error

### DIFF
--- a/brian/brian.py
+++ b/brian/brian.py
@@ -58,14 +58,13 @@ def router(opts):
                 output = "Router input/// Sender -> {}: Receiver -> {}\n"
                 output = output.format(sender, receiver)
                 sys.stdout.write(output)
-            frames = [receiver,sender,empty,data]
-            frames_to_send.append(frames)
+            frames_received = [receiver,sender,empty,data]
+            frames_to_send.append(frames_received)
 
             if __debug__:
                 output = "Router output/// Receiver -> {}: Sender -> {}\n"
                 output = output.format(receiver, sender)
                 sys.stdout.write(output)
-        sent = False
         non_sent = []
         for frames in frames_to_send:
             try:

--- a/brian/brian.py
+++ b/brian/brian.py
@@ -47,28 +47,37 @@ def router(opts):
     router.bind(opts.router_address)
 
     sys.stdout.write("Starting router!\n")
+    frames_to_send = []
     while True:
-        dd = router.recv_multipart()
+        events = router.poll(timeout=1)
+        if events:
+            dd = router.recv_multipart()
 
-        sender, receiver, empty, data = dd
-        if __debug__:
-            output = "Router input/// Sender -> {}: Receiver -> {}\n"
-            output = output.format(sender, receiver)
-            sys.stdout.write(output)
-        frames = [receiver, sender,empty,data]
-        if __debug__:
-            output = "Router output/// Receiver -> {}: Sender -> {}\n"
-            output = output.format(receiver, sender)
-            sys.stdout.write(output)
+            sender, receiver, empty, data = dd
+            if __debug__:
+                output = "Router input/// Sender -> {}: Receiver -> {}\n"
+                output = output.format(sender, receiver)
+                sys.stdout.write(output)
+            frames = [receiver,sender,empty,data]
+            frames_to_send.append(frames)
+
+            if __debug__:
+                output = "Router output/// Receiver -> {}: Sender -> {}\n"
+                output = output.format(receiver, sender)
+                sys.stdout.write(output)
         sent = False
-        while not sent:
+        non_sent = []
+        for frames in frames_to_send:
             try:
                 router.send_multipart(frames)
-                sent = True
             except zmq.ZMQError as e:
                 if __debug__:
-                    sys.stdout.write("Trying to send \n")
-                time.sleep(0.5)
+                    output = "Unable to send frame Receiver -> {}: Sender -> {}\n"
+                    output = output.format(frames[0], frames[1])
+                    sys.stdout.write(output)
+                non_sent.append(frames)
+        frames_to_send = non_sent
+
 
 def sequence_timing(opts):
     """Thread function for sequence timing
@@ -170,12 +179,9 @@ def sequence_timing(opts):
 
     time.sleep(1)
 
-    pulse_seq_times = {}
-    driver_times = {}
-    processing_times = {}
+    last_processing_time = 0
 
     first_time = True
-
     late_counter = 0
     while True:
 
@@ -201,13 +207,11 @@ def sequence_timing(opts):
                 reply_output = reply_output.format(meta.sequence_time*1e3, meta.sequence_num)
                 printing(reply_output)
 
-            driver_times[meta.sequence_num] = meta.sequence_time
-
             #Requesting acknowledgement of work begins from DSP
             if __debug__:
                 printing("Requesting work begins from DSP")
-            so.send_request(brian_to_dsp_begin, opts.dspbegin_to_brian_identity,
-                            "Requesting work begins")
+            iden = opts.dspbegin_to_brian_identity + str(meta.sequence_num)
+            so.send_request(brian_to_dsp_begin, iden, "Requesting work begins")
 
             start_new_sock.send_string("want_to_start")
 
@@ -224,8 +228,6 @@ def sequence_timing(opts):
                 reply_output = reply_output.format(sigp.sequence_num, sigp.sequence_time)
                 printing(reply_output)
 
-            pulse_seq_times[sigp.sequence_num] = sigp.sequence_time
-
             #Request acknowledgement of sequence from driver
             if __debug__:
                 printing("Requesting ack from driver")
@@ -234,7 +236,8 @@ def sequence_timing(opts):
         if brian_to_dsp_begin in socks and socks[brian_to_dsp_begin] == zmq.POLLIN:
 
             #Get acknowledgement that work began in processing.
-            reply = so.recv_obj(brian_to_dsp_begin, opts.dspbegin_to_brian_identity, printing)
+            reply = so.recv_bytes_from_any_iden(brian_to_dsp_begin)
+
             sig_p = sigprocpacket_pb2.SigProcPacket()
             sig_p.ParseFromString(reply)
 
@@ -246,19 +249,17 @@ def sequence_timing(opts):
 
             if __debug__:
                 printing("Requesting work end from DSP")
-            so.send_request(brian_to_dsp_end, opts.dspend_to_brian_identity, "Requesting work ends")
+            iden = opts.dspend_to_brian_identity + str(sig_p.sequence_num)
+            so.send_request(brian_to_dsp_end, iden, "Requesting work ends")
 
-            #acknowledge we want to start something new. We hold out on the first sequence in 
-            #order to keep the first sequence synchronous. This allows the NVIDIA code to 
-            #fully initialize.
-            if sig_p.sequence_num != 0:
-                start_new_sock.send_string("good_to_start")
+            #acknowledge we want to start something new.
+            start_new_sock.send_string("good_to_start")
 
 
         if brian_to_dsp_end in socks and socks[brian_to_dsp_end] == zmq.POLLIN:
 
             #Receive ack that work finished on previous sequence.
-            reply = so.recv_obj(brian_to_dsp_end, opts.dspend_to_brian_identity, printing)
+            reply = so.recv_bytes_from_any_iden(brian_to_dsp_end)
 
             sig_p = sigprocpacket_pb2.SigProcPacket()
             sig_p.ParseFromString(reply)
@@ -268,22 +269,17 @@ def sequence_timing(opts):
                 reply_output = reply_output.format(sig_p.kerneltime, sig_p.sequence_num)
                 printing(reply_output)
 
-            processing_times[sig_p.sequence_num] = sig_p.kerneltime
             if sig_p.sequence_num != 0:
-                if sig_p.kerneltime > processing_times[sig_p.sequence_num-1]:
+                if sig_p.kerneltime > last_processing_time:
                     late_counter += 1
                 else:
                     late_counter = 0
+            last_processing_time = sig_p.kerneltime
 
             if __debug__:
                 printing("Late counter {}".format(late_counter))
 
-            #acknowledge that we are good and able to start something new. We hold out on the first
-            #sequence in order to keep the first sequence synchronous. This allows the NVIDIA code 
-            #to fully initialize.
-            if sig_p.sequence_num == 0:
-            	start_new_sock.send_string("good_to_start")
-
+            #acknowledge that we are good and able to start something new.
             start_new_sock.send_string("extra_good_to_start")
 
 def main():

--- a/data_write/data_write.py
+++ b/data_write/data_write.py
@@ -1198,10 +1198,16 @@ def main():
 
             # This is needed to check that if we have a backlog, there are no more
             # skipped sequence numbers we are still waiting for.
+            break_now = False
             for i, pd in enumerate(sorted_q):
                 if pd.sequence_num != expected_sqn_num + i:
                     expected_sqn_num += i
-                    continue
+                    break_now = True
+                    break
+            if break_now:
+                continue
+                
+                
             expected_sqn_num = sorted_q[-1].sequence_num + 1
 
             for pd in sorted_q:

--- a/data_write/data_write.py
+++ b/data_write/data_write.py
@@ -1168,6 +1168,7 @@ def main():
     first_time = True
     expected_sqn_num = 0
     queued_sqns = []
+    abandon_list = []
     while True:
 
         try:
@@ -1191,6 +1192,7 @@ def main():
 
             queued_sqns.append(processed_data)
             # Check if any data processing finished out of order.
+
             if processed_data.sequence_num != expected_sqn_num:
                 continue
 
@@ -1205,9 +1207,12 @@ def main():
                     break_now = True
                     break
             if break_now:
+                if len(sorted_q) > 20:
+                    #TODO error out correctly
+                    printing("Lost sequence #{}. Exiting.".format(expected_sqn_num))
+                    sys.exit()
                 continue
-                
-                
+
             expected_sqn_num = sorted_q[-1].sequence_num + 1
 
             for pd in sorted_q:

--- a/rx_signal_processing/dsp.hpp
+++ b/rx_signal_processing/dsp.hpp
@@ -84,8 +84,7 @@ class DSPCore {
                                             std::vector<uint32_t> total_output_samples);
   void initial_memcpy_callback();
   //http://en.cppreference.com/w/cpp/language/explicit
-  explicit DSPCore(zmq::socket_t *ack_s, zmq::socket_t *timing_s, zmq::socket_t *data_write_socket,
-                    SignalProcessingOptions &options, uint32_t sq_num,
+  explicit DSPCore(zmq::context_t &context, SignalProcessingOptions &options, uint32_t sq_num,
                     double rx_rate, double output_sample_rate,
                     std::vector<std::vector<float>> filter_taps,
                     std::vector<cuComplex> beam_phases,
@@ -154,14 +153,8 @@ class DSPCore {
   //! Output sampling rate of the filtered, decimated, processed data.
   double output_sample_rate;
 
-  //! Pointer to the socket used to acknowledge the RF samples have been copied to device.
-  zmq::socket_t *ack_socket;
-
-  //! Pointer to the socket used to report the timing of GPU kernels.
-  zmq::socket_t *timing_socket;
-
-  //! Pointer to the data writing socket.
-  zmq::socket_t *data_socket;
+  //! The unique sockets for communicating between processes.
+  std::vector<zmq::socket_t> zmq_sockets;
 
   //! Stores the total GPU process timing once all the work is done.
   float total_process_timing_ms;

--- a/rx_signal_processing/rx_dsp_chain.cu
+++ b/rx_signal_processing/rx_dsp_chain.cu
@@ -39,19 +39,13 @@ int main(int argc, char **argv){
   zmq::context_t context(1); // 1 is context num. Only need one per program as per examples
   auto identities = {sig_options.get_dsp_radctrl_identity(),
                    sig_options.get_dsp_driver_identity(),
-                   sig_options.get_dsp_exphan_identity(),
-                   sig_options.get_dsp_dw_identity(),
-                   sig_options.get_dspbegin_brian_identity(),
-                   sig_options.get_dspend_brian_identity()};
+                   sig_options.get_dsp_exphan_identity()};
 
   auto sockets_vector = create_sockets(context, identities, sig_options.get_router_address());
 
   zmq::socket_t &dsp_to_radar_control = sockets_vector[0];
   zmq::socket_t &dsp_to_driver = sockets_vector[1];
   zmq::socket_t &dsp_to_experiment_handler = sockets_vector[2];
-  zmq::socket_t &dsp_to_data_write = sockets_vector[3];
-  zmq::socket_t &dsp_to_brian_begin = sockets_vector[4];
-  zmq::socket_t &dsp_to_brian_end = sockets_vector[5];
 
   auto gpu_properties = get_gpu_properties();
   print_gpu_properties(gpu_properties);
@@ -236,8 +230,8 @@ int main(int argc, char **argv){
 
     auto complex_taps = filters.get_mixed_filter_taps();
 
-    DSPCore *dp = new DSPCore(&dsp_to_brian_begin, &dsp_to_brian_end, &dsp_to_data_write,
-                             sig_options, sp_packet.sequence_num(), rx_rate, output_sample_rate,
+    DSPCore *dp = new DSPCore(std::ref(context), sig_options, sp_packet.sequence_num(),
+                             rx_rate, output_sample_rate,
                              filter_taps, beam_phases,
                              rx_metadata.initialization_time(),
                              rx_metadata.sequence_start_time(), dm_rates, slice_info);

--- a/utils/zmq_borealis_helpers/socket_operations.py
+++ b/utils/zmq_borealis_helpers/socket_operations.py
@@ -57,7 +57,6 @@ def recv_data(socket, sender_iden, pprint):
     else:
         return data.decode('utf-8')
 
-
 def send_data(socket, recv_iden, msg):
     """Sends data to another identity.
 
@@ -74,7 +73,7 @@ def send_data(socket, recv_iden, msg):
 # Aliases for sending to a socket
 send_reply = send_request = send_data
 
-# Aliases for receiving from a socket 
+# Aliases for receiving from a socket
 recv_reply = recv_request = recv_data
 
 def recv_bytes(socket, sender_iden, pprint):
@@ -97,6 +96,18 @@ def recv_bytes(socket, sender_iden, pprint):
         return None
     else:
         return bytes_object
+
+def recv_bytes_from_any_iden(socket):
+    """Receives data from a socket and verifies it comes from the correct sender.
+
+    :param socket: Socket to recv from.
+    :type socket: Zmq socket
+    :returns: Received data
+    :rtype: String or Protobuf or None
+    """
+
+    recv_identity, empty, bytes_object = socket.recv_multipart()
+    return bytes_object
 
 
 def send_bytes(socket, recv_iden, bytes_object):

--- a/utils/zmq_borealis_helpers/socket_operations.py
+++ b/utils/zmq_borealis_helpers/socket_operations.py
@@ -98,7 +98,7 @@ def recv_bytes(socket, sender_iden, pprint):
         return bytes_object
 
 def recv_bytes_from_any_iden(socket):
-    """Receives data from a socket and verifies it comes from the correct sender.
+    """Receives data from a socket, returns just the data and strips off the identity
 
     :param socket: Socket to recv from.
     :type socket: Zmq socket

--- a/utils/zmq_borealis_helpers/zmq_borealis_helpers.cpp
+++ b/utils/zmq_borealis_helpers/zmq_borealis_helpers.cpp
@@ -57,9 +57,6 @@ void router(zmq::context_t &context, std::string router_address)
     auto empty = input.popstr();
     auto data_msg = input.popstr();
 
-    //std::cout << <<sender <<
-
-
     auto sent = false;
     while(!sent) {
       try {


### PR DESCRIPTION
Fixign the issues where dsp threads would land up accessing the socket
at the same time causing an error. I eliminate this issue by creating
unique sockets with unique identities in each thread. For this to work i
needed to create a new recv method to receive from any identity. I then
append the sequence num to each sender iden to keep them unique.

The problem here is this means that sequences may finish out of order.
For that reason, I added logic to make sure that sequences get ordered
correctly.

I had to rework the router a bit too. We land up sending to identities
that dont exist yet, and this landed up blocking the code. I had to
rework this to queue up frames to send so they dont block other frames
that need to move through the system.