### PR TITLE
Fixing bug that happens when searching in scd

### DIFF
--- a/scheduler/remote_server.py
+++ b/scheduler/remote_server.py
@@ -484,19 +484,7 @@ def get_relevant_lines(scd_util, time_of_interest):
     relevant_lines = scd_util.get_relevant_lines(yyyymmdd, hhmm)
     while not found:
 
-        if not relevant_lines:
-            msg = "Error in schedule: Could not find any relevant_lines. Either no lines exist " \
-            "or an infinite duration line could not be found."
-
-            raise ValueError(msg)
-
-        lines_dict = {}
         for line in relevant_lines:
-            if line['timestamp'] not in lines_dict:
-                lines_dict[line['timestamp']] = []
-            lines_dict[line['timestamp']].append(line)
-
-        for line in lines_dict[list(lines_dict)[0]]:
             if line['duration'] == '-':
                 found = True
 
@@ -507,11 +495,6 @@ def get_relevant_lines(scd_util, time_of_interest):
             hhmm = time.strftime("%H:%M")
 
             new_relevant_lines = scd_util.get_relevant_lines(yyyymmdd, hhmm)
-            if not new_relevant_lines:
-                msg = "Error in schedule: Could not find any relevant_lines. Either no lines exist "\
-                "or an infinite duration line could not be found."
-
-                raise ValueError(msg)
 
             lines_diff = [d for d in new_relevant_lines if d not in relevant_lines]
 
@@ -559,7 +542,7 @@ def _main():
         log_msg_header = "Updated at {}\n".format(time_of_interest)
         try:
             relevant_lines = get_relevant_lines(scd_util, time_of_interest)
-        except ValueError as e:
+        except (IndexError,ValueError) as e:
             error_msg = ("{logtime}: Unable to make schedule\n"
                          "\t Exception thrown:\n"
                          "\t\t {exception}\n")

--- a/scheduler/scd_utils.py
+++ b/scheduler/scd_utils.py
@@ -217,6 +217,9 @@ class SCDUtils(object):
 
         scd_lines = self.read_scd()
 
+        if not scd_lines:
+            raise IndexError("Schedule file is empty. No lines can be returned")
+
         epoch = dt.datetime.utcfromtimestamp(0)
         epoch_milliseconds = int((time - epoch).total_seconds() * 1000)
 

--- a/scheduler/scd_utils.py
+++ b/scheduler/scd_utils.py
@@ -207,6 +207,7 @@ class SCDUtils(object):
 
         Raises:
             ValueError: If datetime could not be created from supplied arguments.
+            IndexError: If schedule file is empty
         """
 
         try:


### PR DESCRIPTION
SCD code was not properly locating the last line in the scd file if the
current date was ahead of any lines in the schedule.