### PR TITLE
Modifying ssdelay calculation

### DIFF
--- a/experiment_prototype/experiment_prototype.py
+++ b/experiment_prototype/experiment_prototype.py
@@ -122,7 +122,9 @@ pulse_len
     length of pulse in us. Range gate size is also determined by this.
 
 num_ranges
-    Number of range gates.
+    Number of range gates to receive for. 
+    Range gate time is equal to pulse_len and range gate distance is 
+    the range_sep, calculated from pulse_len.
 
 first_range
     first range gate, in km


### PR DESCRIPTION
- num_ranges time is based on pulse_len, not output_rx_rate
  (although they will have the same result if acfs is True because
   in that case we force pulse_len = 1/output_rx_rate)
- updated comment on num_ranges to clarify this