### PR TITLE
Quick fix to avoid edges of our tx/rx bandwidths. See Issue #195

### DIFF
--- a/experiment_prototype/experiment_prototype.py
+++ b/experiment_prototype/experiment_prototype.py
@@ -635,7 +635,9 @@ class ExperimentPrototype(object):
         The maximum transmit frequency.
 
         This is the maximum tx frequency possible in this experiment (either maximum in our license
-        or maximum given by the centre frequency and sampling rate).
+        or maximum given by the centre frequency, and sampling rate). The maximum is slightly less
+        than that allowed by the centre frequency and txrate, to stay away from the edges of the
+        possible transmission band where the signal is distorted.
         """
         max_freq = self.txctrfreq * 1000 + (self.txrate/2.0) - transition_bandwidth
         if max_freq < self.options.max_freq:
@@ -650,7 +652,9 @@ class ExperimentPrototype(object):
         The minimum transmit frequency.
 
         This is the minimum tx frequency possible in this experiment (either minimum in our license
-        or minimum given by the centre frequency and sampling rate).
+        or minimum given by the centre frequency and sampling rate). The minimum is slightly more
+        than that allowed by the centre frequency and txrate, to stay away from the edges of the
+        possible transmission band where the signal is distorted.
         """
         min_freq = self.txctrfreq * 1000 - (self.txrate/2.0) + transition_bandwidth
         if min_freq > self.options.min_freq:
@@ -672,7 +676,9 @@ class ExperimentPrototype(object):
         The maximum receive frequency.
 
         This is the maximum tx frequency possible in this experiment (maximum given by the centre
-        frequency and sampling rate), as license doesn't matter for receiving.
+        frequency and sampling rate), as license doesn't matter for receiving. The maximum is
+        slightly less than that allowed by the centre frequency and rxrate, to stay away from the
+        edges of the possible receive band where the signal may be distorted.
         """
         max_freq = self.rxctrfreq * 1000 + (self.rxrate/2.0) - transition_bandwidth
         return max_freq
@@ -683,7 +689,9 @@ class ExperimentPrototype(object):
         The minimum receive frequency.
 
         This is the minimum rx frequency possible in this experiment (minimum given by the centre
-        frequency and sampling rate) - license doesn't restrict receiving.
+        frequency and sampling rate) - license doesn't restrict receiving. The minimum is
+        slightly more than that allowed by the centre frequency and rxrate, to stay away from the
+        edges of the possible receive band where the signal may be distorted.
         """
         min_freq = self.rxctrfreq * 1000 - (self.rxrate/2.0) + transition_bandwidth
         if min_freq > 1000: #Hz
@@ -1106,7 +1114,7 @@ class ExperimentPrototype(object):
             if exp_slice['clrfrqrange'][0] >= exp_slice['clrfrqrange'][1]:
                 errmsg = """clrfrqrange must be between min and max tx frequencies {} and rx
                             frequencies {} according to license and/or centre frequencies / sampling
-                            rates, and must have lower frequency first.
+                            rates / transition bands, and must have lower frequency first.
                             """.format((self.tx_minfreq, self.tx_maxfreq),
                                        (self.rx_minfreq, self.rx_maxfreq))
                 raise ExperimentException(errmsg)
@@ -1114,7 +1122,7 @@ class ExperimentPrototype(object):
                     (exp_slice['clrfrqrange'][1] * 1000) >= self.rx_maxfreq:
                 errmsg = """clrfrqrange must be between min and max tx frequencies {} and rx
                             frequencies {} according to license and/or centre frequencies / sampling
-                            rates, and must have lower frequency first.
+                            rates / transition bands, and must have lower frequency first.
                             """.format((self.tx_minfreq, self.tx_maxfreq),
                                        (self.rx_minfreq, self.rx_maxfreq))
                 raise ExperimentException(errmsg)
@@ -1122,7 +1130,7 @@ class ExperimentPrototype(object):
                     (exp_slice['clrfrqrange'][0] * 1000) <= self.rx_minfreq:
                 errmsg = """clrfrqrange must be between min and max tx frequencies {} and rx
                             frequencies {} according to license and/or centre frequencies / sampling
-                            rates, and must have lower frequency first.
+                            rates / transition bands, and must have lower frequency first.
                             """.format((self.tx_minfreq, self.tx_maxfreq),
                                        (self.rx_minfreq, self.rx_maxfreq))
                 raise ExperimentException(errmsg)
@@ -1176,14 +1184,14 @@ class ExperimentPrototype(object):
             if not isinstance(exp_slice['rxfreq'], int) and not isinstance(exp_slice['rxfreq'],
                                                                       float):
                 errmsg = """rxfreq must be a number (kHz) between rx min and max frequencies {} for
-                            the radar license and be within range given centre frequency and
-                            sampling rate.""".format((self.rx_minfreq, self.rx_maxfreq))
+                            the radar license and be within range given centre frequency, sampling 
+                            rate and transition band.""".format((self.rx_minfreq, self.rx_maxfreq))
                 raise ExperimentException(errmsg)
             if (exp_slice['rxfreq'] * 1000) >= self.rx_maxfreq or (exp_slice['rxfreq'] *
                                                                    1000) <= self.rx_minfreq:
                 errmsg = """rxfreq must be a number (kHz) between rx min and max frequencies {} for
-                            the radar license and be within range given centre frequency and
-                            sampling rate.""".format((self.rx_minfreq, self.rx_maxfreq))
+                            the radar license and be within range given centre frequency, sampling
+                            rate and transition band.""".format((self.rx_minfreq, self.rx_maxfreq))
                 raise ExperimentException(errmsg)
 
         else:  # TX-specific mode , without a clear frequency search.
@@ -1192,7 +1200,7 @@ class ExperimentPrototype(object):
                                                                           float):
                 errmsg = """txfreq must be a number (kHz) between tx min and max frequencies {} and
                             rx min and max frequencies {} for the radar license and be within range
-                            given centre frequencies and sampling rates.
+                            given centre frequencies, sampling rates and transition band.
                             """.format((self.tx_minfreq, self.tx_maxfreq),
                                        (self.rx_minfreq, self.rx_maxfreq))
                 raise ExperimentException(errmsg)
@@ -1200,7 +1208,7 @@ class ExperimentPrototype(object):
                     self.rx_maxfreq:
                 errmsg = """txfreq must be a number (kHz) between tx min and max frequencies {} and
                             rx min and max frequencies {} for the radar license and be within range
-                            given centre frequencies and sampling rates.
+                            given centre frequencies, sampling rates and transition band.
                             """.format((self.tx_minfreq, self.tx_maxfreq),
                                        (self.rx_minfreq, self.rx_maxfreq))
                 raise ExperimentException(errmsg)
@@ -1208,7 +1216,7 @@ class ExperimentPrototype(object):
                     self.rx_minfreq:
                 errmsg = """txfreq must be a number (kHz) between tx min and max frequencies {} and
                             rx min and max frequencies {} for the radar license and be within range
-                            given centre frequencies and sampling rates.
+                            given centre frequencies, sampling rates and transition band.
                             """.format((self.tx_minfreq, self.tx_maxfreq),
                                        (self.rx_minfreq, self.rx_maxfreq))
                 raise ExperimentException(errmsg)

--- a/experiment_prototype/experiment_prototype.py
+++ b/experiment_prototype/experiment_prototype.py
@@ -216,6 +216,7 @@ therefore ignored.
 
 default_rx_bandwidth = 5.0e6
 default_output_rx_rate = 10.0e3/3
+transition_bandwidth = 750.0e3
 
 class ExperimentPrototype(object):
     """
@@ -636,7 +637,7 @@ class ExperimentPrototype(object):
         This is the maximum tx frequency possible in this experiment (either maximum in our license
         or maximum given by the centre frequency and sampling rate).
         """
-        max_freq = self.txctrfreq * 1000 + (self.txrate/2.0)
+        max_freq = self.txctrfreq * 1000 + (self.txrate/2.0) - transition_bandwidth
         if max_freq < self.options.max_freq:
             return max_freq
         else:
@@ -651,7 +652,7 @@ class ExperimentPrototype(object):
         This is the minimum tx frequency possible in this experiment (either minimum in our license
         or minimum given by the centre frequency and sampling rate).
         """
-        min_freq = self.txctrfreq * 1000 - (self.txrate/2.0)
+        min_freq = self.txctrfreq * 1000 - (self.txrate/2.0) + transition_bandwidth
         if min_freq > self.options.min_freq:
             return min_freq
         else:
@@ -673,7 +674,7 @@ class ExperimentPrototype(object):
         This is the maximum tx frequency possible in this experiment (maximum given by the centre
         frequency and sampling rate), as license doesn't matter for receiving.
         """
-        max_freq = self.rxctrfreq * 1000 + (self.rxrate/2.0)
+        max_freq = self.rxctrfreq * 1000 + (self.rxrate/2.0) - transition_bandwidth
         return max_freq
 
     @property
@@ -684,7 +685,7 @@ class ExperimentPrototype(object):
         This is the minimum rx frequency possible in this experiment (minimum given by the centre
         frequency and sampling rate) - license doesn't restrict receiving.
         """
-        min_freq = self.rxctrfreq * 1000 - (self.rxrate/2.0)
+        min_freq = self.rxctrfreq * 1000 - (self.rxrate/2.0) + transition_bandwidth
         if min_freq > 1000: #Hz
             return min_freq
         else:


### PR DESCRIPTION
I _think_ this is all that's required, I couldn't find any other references to calculations for max and min frequencies.

If you two think there's a better way, let me know. Also if you think I shouldn't use a global, let me know. I think this should go to master ASAP to avoid any funky waveforms.