### PR TITLE
Adding O3 for nvcc compilation in release

### DIFF
--- a/site_scons/site_config.py
+++ b/site_scons/site_config.py
@@ -130,6 +130,7 @@ ENV_EXTENSIONS = {
     'release': dict(
         # Extra flags for release C++ builds
         CCFLAGS = ['-DNDEBUG','-O3'],
+        NVCCFLAGS = ['-DNDEBUG','-O3'],
     ),
 }
 


### PR DESCRIPTION
I noticed that cuda code was not being compiled with optimization.
Should add some speed increases for when that matters