### PR TITLE
Enh/experiment prints

### DIFF
--- a/experiment_handler/experiment_handler.py
+++ b/experiment_handler/experiment_handler.py
@@ -205,7 +205,7 @@ def experiment_handler(semaphore):
                 printing("Building an updated experiment.")
             exp.build_scans()
             printing("Experiment {exp} with CPID {cp} successfully updated"
-                     .format(exp=exp, cp=exp.cpid))
+                     .format(exp=exp.__class__.__name__, cp=exp.cpid))
         semaphore.release()
 
 

--- a/experiment_handler/experiment_handler.py
+++ b/experiment_handler/experiment_handler.py
@@ -194,7 +194,7 @@ def experiment_handler(semaphore):
         #                               "Need completed data")
 
         #data = socket_operations.recv_data(exp_handler_to_dsp,
-        #                                   options.dsp_to_exphan_identity, printing)
+        #                             options.dsp_to_exphan_identity, printing)
 
         some_data = None  # TODO get the data from data socket and pass to update
         
@@ -204,6 +204,8 @@ def experiment_handler(semaphore):
             if __debug__:
                 printing("Building an updated experiment.")
             exp.build_scans()
+            printing("Experiment {exp} with CPID {cp} successfully updated"
+                     .format(exp=exp, cp=exp.cpid))
         semaphore.release()
 
 
@@ -212,9 +214,12 @@ def experiment_handler(semaphore):
     while True:
 
         if not change_flag:
-            serialized_exp = pickle.dumps(None, protocol=pickle.HIGHEST_PROTOCOL)
+            serialized_exp = pickle.dumps(None, 
+                                          protocol=pickle.HIGHEST_PROTOCOL)
         else:
             exp.build_scans()
+            printing("Sucessful experiment {exp} built with CPID {cp}".format(
+                     exp=exp, cp=exp.cpid))
             serialized_exp = pickle.dumps(exp, protocol=pickle.HIGHEST_PROTOCOL)
             # use the newest, fastest protocol (currently version 4 in python 3.4+)            
             change_flag = False

--- a/experiment_handler/experiment_handler.py
+++ b/experiment_handler/experiment_handler.py
@@ -219,7 +219,7 @@ def experiment_handler(semaphore):
         else:
             exp.build_scans()
             printing("Sucessful experiment {exp} built with CPID {cp}".format(
-                     exp=exp, cp=exp.cpid))
+                     exp=exp.__class__.__name__, cp=exp.cpid))
             serialized_exp = pickle.dumps(exp, protocol=pickle.HIGHEST_PROTOCOL)
             # use the newest, fastest protocol (currently version 4 in python 3.4+)            
             change_flag = False

--- a/utils/experiment_options/experimentoptions.py
+++ b/utils/experiment_options/experimentoptions.py
@@ -221,8 +221,6 @@ class ExperimentOptions:
                     \n    minimum_tau_spacing_length = {} \
                     \n    minimum_pulse_separation = {} \
                     \n    tr_window_time = {} \
-                    \n    atten_window_time_start = {} \
-                    \n    atten_window_time_end = {} \
                     \n    default_freq = {} \
                     \n    restricted_ranges = {} \
                      """.format(self.main_antenna_count, self.interferometer_antenna_count,
@@ -238,7 +236,6 @@ class ExperimentOptions:
                                 self.max_range_gates, self.max_beams, self.max_freq, self.min_freq,
                                 self. minimum_pulse_length, self.minimum_tau_spacing_length,
                                 self.minimum_pulse_separation, self.tr_window_time,
-                                self.atten_window_time_start, self.atten_window_time_end,
                                 self.default_freq, self.restricted_ranges)
         return return_str
 


### PR DESCRIPTION
should resolve #208 
Experiment handler now prints name of experiment class and the CPID (these are experiment specific) 
The other requests in the issue, like frequency and beams, are slice specific so it'd be my preference to not print all slices here (could be messy). For most experiments, I think printing the experiment gives enough information? 
As part of an update for the IB_collab_mode, I added a printing method to the experiment_prototype class so when you write your experiment it can print whatever you'd like. Example below: IB_collab_mode print is from within the IB_collab_mode experiment and lets you know which frequency it picked when it was initialized. 
![exp_handler_print](https://user-images.githubusercontent.com/19413948/86811004-aeb5af00-c03a-11ea-9f6f-cd63872e6f9f.png)
