### PR TITLE
scan start fix

### DIFF
--- a/data_write/data_write.py
+++ b/data_write/data_write.py
@@ -1115,7 +1115,7 @@ class DataWrite(object):
             write_tx_data()
 
         end = time.time()
-        printing("Time to write: {} ms".format((end - start) * 1000))
+        printing("Time to write to {}: {} ms".format(dataset_name, (end - start) * 1000))
 
 
 def main():

--- a/radar_control/radar_control.py
+++ b/radar_control/radar_control.py
@@ -674,7 +674,10 @@ def radar():
                         time_elapsed = integration_period_start_time - start_minute
                         if scan_iter < len(scan.scanbound) - 1:
                             scanbound_time = scan.scanbound[scan_iter + 1]
-                            # TODO: may be negative, perhaps calculate which 'beam' instead
+                            # TODO: scanbound_time could be in the past if system has taken 
+                            # too long, perhaps calculate which 'beam' (scan_iter) instead by 
+                            # rewriting this code for an experiment-wide scanbound attribute instead
+                            # of individual scanbounds inside the scan objects
                             # TODO: if scan_iter skips ahead, aveperiod.beam_iter may also need to if scan.align_to_beamorder is True
                             bound_time_remaining = scanbound_time - time_elapsed.total_seconds()
                         else:

--- a/radar_control/radar_control.py
+++ b/radar_control/radar_control.py
@@ -715,6 +715,7 @@ def radar():
                     time_to_prep_aveperiod = datetime.utcnow() - time_start_of_aveperiod
                     rad_ctrl_print('Time to prep aveperiod: {}'.format(time_to_prep_aveperiod))
 
+                #  Time to start averaging in the below loop
                 num_sequences = 0
                 time_remains = True
                 while time_remains:

--- a/radar_control/radar_control.py
+++ b/radar_control/radar_control.py
@@ -691,7 +691,6 @@ def radar():
                             # reduce the integration period to only the time remaining
                             # until the next scan boundary.
                             # TODO: Check for integration_period_done_time < 0
-                            # integration_period_done_time is in units of ms
                             integration_period_done_time = integration_period_start_time + \
                                             timedelta(milliseconds=bound_time_remaining * 1e3)
                         else:

--- a/radar_control/radar_control.py
+++ b/radar_control/radar_control.py
@@ -791,7 +791,6 @@ def radar():
                                                repeat=pulse_dict['isarepeat'])
                             first_sequence_out = True
 
-                        # TODO: Make sure you can have a slice that doesn't transmit, only receives on a frequency. # REVIEW #1 what do you mean, what is this TODO for? REPLY : driver acks wouldn't be required etc need to make sure this is possible
                         # Sequence is done
                         num_sequences += 1
 

--- a/radar_control/radar_control.py
+++ b/radar_control/radar_control.py
@@ -723,7 +723,7 @@ def radar():
 
                         # Alternating sequences if there are multiple in the averaging_period.
                         time_now = datetime.utcnow()
-                        if intt_break:  # TODO: Check if integration_period_done_time is in past
+                        if intt_break:
                             if time_now >= integration_period_done_time:
                                 time_remains = False
                                 integration_period_time = (time_now - integration_period_start_time)

--- a/radar_control/radar_control.py
+++ b/radar_control/radar_control.py
@@ -632,7 +632,6 @@ def radar():
                         debug_samples.append(sequence_samples_dict)
 
                 # all phases are set up for this averaging period for the beams required.
-                # Time to start averaging in the below loop.
 
                 if not scan.scanbound:
                     integration_period_start_time = datetime.utcnow()  # ms

--- a/radar_control/radar_control.py
+++ b/radar_control/radar_control.py
@@ -690,7 +690,10 @@ def radar():
                         if bound_time_remaining < aveperiod.intt * 1e-3:
                             # reduce the integration period to only the time remaining
                             # until the next scan boundary.
-                            # TODO: Check for integration_period_done_time < 0
+                            # TODO: Check for bound_time_remaining > 0
+                            # to be sure there is actually time to run this intt
+                            # (if bound_time_remaining < 0, we need a solution to 
+                            # reset)
                             integration_period_done_time = integration_period_start_time + \
                                             timedelta(milliseconds=bound_time_remaining * 1e3)
                         else:


### PR DESCRIPTION
This PR was tested via the test setup at the lab, it appears to run fine (visually inspecting log files) for all RCPs tested (twofsound, normalscan, interleavesound, etc)


Add more informative message to data write (note that slice_id and data format are not available at that point in the code)

radar_control.py:
Added debug statements
PEP8 standards applied (mostly) where it made sense.
small fix to scan start times as proposed by Marci
Added todo statements for future checks to negative times
Move num_sequences and time_remains initializations to just above where they are used
removed redundant if scan_iter == scan.num_aveperiods_in_scan (it's checked in the while loop just above it)