### PR TITLE
Hotfix cpid uniqueness

### DIFF
--- a/experiment_prototype/experiment_prototype.py
+++ b/experiment_prototype/experiment_prototype.py
@@ -346,7 +346,7 @@ class ExperimentPrototype(object):
         # Quickly check for uniqueness with a search in the experiments directory first
         # taking care not to look for CPID in any experiments that are just tests (start with the
         # word 'test')
-        experiment_files_list = list(Path(BOREALISPATH + "/experiments/").glob("[!test]*.py"))
+        experiment_files_list = list(Path(BOREALISPATH + "/experiments/").glob("*.py"))
         self.__experiment_name = self.__class__.__name__  # TODO use this to check the cpid is correct using pygit2, or __class__.__module__ for module name
         cpid_list = []
         for experiment_file in experiment_files_list:
@@ -355,15 +355,16 @@ class ExperimentPrototype(object):
                     # Find the name of the class in the file and break if it matches this class
                     experiment_class_name = re.findall("class.*\(ExperimentPrototype\):", line)
                     if experiment_class_name:
-                        # Parse out just the name from the experiment, (format will be like this: ['class IBCollabMode(ExperimentPrototype):'] )
+                        # Parse out just the name from the experiment, format will be like this:
+                        # ['class IBCollabMode(ExperimentPrototype):']
                         atomic_class_name = experiment_class_name[0].split()[1].split('(')[0]
                         if self.__experiment_name == atomic_class_name:
                             break
 
                     # Find any lines that have 'cpid = [integer]'
-                    existing_cpid = re.findall("cpid = [0-9]+", line)
+                    existing_cpid = re.findall("cpid.?=.?[0-9]+", line)
                     if existing_cpid:
-                        cpid_list.append(existing_cpid[0].split()[2])
+                        cpid_list.append(existing_cpid[0].split('=')[1].strip())
 
         if str(cpid) in cpid_list:
             errmsg = 'CPID must be unique. {} is in use by another local experiment'.format(cpid)

--- a/experiment_prototype/experiment_prototype.py
+++ b/experiment_prototype/experiment_prototype.py
@@ -344,8 +344,8 @@ class ExperimentPrototype(object):
             errmsg = 'CPID must be a unique int'
             raise ExperimentException(errmsg)
         # Quickly check for uniqueness with a search in the experiments directory first
-        # taking care not to look for CPID in any experiments that are just tests (start with the
-        # word 'test')
+        # taking care not to look for CPID in any experiments that are just tests (not located
+        # in the testing directory)
         experiment_files_list = list(Path(BOREALISPATH + "/experiments/").glob("*.py"))
         self.__experiment_name = self.__class__.__name__  # TODO use this to check the cpid is correct using pygit2, or __class__.__module__ for module name
         cpid_list = []

--- a/tools/testing_utils/experiments/experiment_unittests.py
+++ b/tools/testing_utils/experiments/experiment_unittests.py
@@ -34,7 +34,7 @@ input_test_file = BOREALISPATH + "/tools/testing_utils/experiments/experiment_te
 # Call experiment handler main function like so: eh.main(['normalscan', 'discretionary'])
 import experiment_handler.experiment_handler as eh
 from experiment_prototype.experiment_exception import ExperimentException
-
+import experiments.superdarn_common_fields as scf
 
 def ehmain(experiment='normalscan', scheduling_mode='discretionary'):
     """
@@ -89,15 +89,18 @@ class TestExperimentEnvSetup(unittest.TestCase):
         """
         Test the code that checks for the hdw.dat file
         """
+        site_name = scf.opts.site_id
         # Rename the hdw.dat file temporarily
-        os.rename(BOREALISPATH + '/hdw.dat.sas', BOREALISPATH + '/_hdw.dat.sas')
+        os.rename(BOREALISPATH + '/hdw.dat.{}'.format(site_name),
+                  BOREALISPATH + '/_hdw.dat.{}'.format(site_name))
         with self.assertRaisesRegex(ExperimentException, "Cannot open hdw.dat.[a-z]{3} file at"):
              ehmain()
         # experiment_prototype.experiment_exception.ExperimentException: Cannot open hdw.dat.sas
         # file at /home/kevin/PycharmProjects/borealis//hdw.dat.sas
 
         # Now rename the hdw.dat file and move on
-        os.rename(BOREALISPATH + '/_hdw.dat.sas', BOREALISPATH + '/hdw.dat.sas')
+        os.rename(BOREALISPATH + '/_hdw.dat.{}'.format(site_name),
+                  BOREALISPATH + '/hdw.dat.{}'.format(site_name))
 
 
 class TestExperimentExceptions(unittest.TestCase):


### PR DESCRIPTION
Tested on lab setup. This will cause the radar to stop if it tries to run a program where the CPID is not unique.
