### PR TITLE
Suppressed NaturalNameWarning when writing hdf5 files.

### DIFF
--- a/data_write/data_write.py
+++ b/data_write/data_write.py
@@ -23,6 +23,7 @@ import argparse as ap
 import numpy as np
 import deepdish as dd
 import posix_ipc as ipc
+import tables
 import zmq
 import faulthandler
 from scipy.constants import speed_of_light
@@ -595,8 +596,8 @@ class DataWrite(object):
         time_stamped_dd = {}
         time_stamped_dd[dt_str] = data_dict
 
-        # TODO(keith): Investigate warning.
-
+        warnings.simplefilter('ignore', tables.NaturalNameWarning)
+        
         try:
             dd.io.save(filename, time_stamped_dd, compression=None)
         except Exception as e:


### PR DESCRIPTION
Small fix, just ignore the warning. A discussion on the reason for the warning can be found here: https://stackoverflow.com/questions/58414068/how-to-get-rid-of-naturalnamewarning

