### PR TITLE
Updating CPIDs

### DIFF
--- a/experiments/2multifsound.py
+++ b/experiments/2multifsound.py
@@ -14,7 +14,7 @@ import experiments.superdarn_common_fields as scf
 class TwoMultifsound(ExperimentPrototype):
 
     def __init__(self):
-        cpid = 350300
+        cpid = 3570
 
         if scf.IS_FORWARD_RADAR:
             beams_to_use = scf.STD_16_FORWARD_BEAM_ORDER

--- a/experiments/normalscan_boresite.py
+++ b/experiments/normalscan_boresite.py
@@ -15,7 +15,7 @@ from experiment_prototype.decimation_scheme.decimation_scheme import DecimationS
 class NormalscanBoresite(ExperimentPrototype):
     # with 7 PULSE sequence
     def __init__(self):
-        cpid = 100000000
+        cpid = 3582
 
         super(NormalscanBoresite, self).__init__(cpid)
 

--- a/experiments/normalscan_single_beam.py
+++ b/experiments/normalscan_single_beam.py
@@ -15,7 +15,7 @@ from experiment_prototype.decimation_scheme.decimation_scheme import DecimationS
 class NormalscanSingleBeam(ExperimentPrototype):
     # with 7 PULSE sequence
     def __init__(self):
-        cpid = 100000000
+        cpid = 3581
 
         super(NormalscanSingleBeam, self).__init__(cpid)
 

--- a/experiments/power_meter_mode.py
+++ b/experiments/power_meter_mode.py
@@ -18,7 +18,7 @@ class PowerMeterMode(ExperimentPrototype):
         freq: int
 
         """
-        cpid = 1010101
+        cpid = 3580
         super(PowerMeterMode, self).__init__(cpid)
 
         if scf.IS_FORWARD_RADAR:


### PR DESCRIPTION
 to be within 16 bits. Overflows will occur in RAWACF fields if they are larger than 16 bits.