### PR TITLE
Fixed UHD instance throwing late errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@
 bin/
 build/
 *.dat
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 Borealis - A control system for USRP based digital radars
 =========================================================
 
+## Low Bandwidth Modification
+The default bandwidth for Borealis is 5 MHz, this modification shrinks the bandwidth to 500 kHz. This fork also fixes an issue where the USRP Driver will send timed USRP packets that occur in the past by bumping up the command delay time.
+
+Run the code using:
+```
+$ source mode release
+$ scons
+$ python3 steamed_hams.py normalscan_low_bw release common
+$ screen -r
+```
+
+To kill the application use:
+```
+$ screen -list
+$ screen -X -S <ID> quit
+```
+
 See our latest documentation here: https://borealis.readthedocs.io/en/latest/ 
 
 Software setup specifically can be found here: https://borealis.readthedocs.io/en/latest/setup_software.html

--- a/experiment_prototype/decimation_scheme/decimation_scheme.py
+++ b/experiment_prototype/decimation_scheme/decimation_scheme.py
@@ -131,19 +131,19 @@ def create_default_scheme():
     :return DecimationScheme: a decimation scheme for use in experiment.
     """
 
-    rates = [5.0e6, 500.0e3, 100.0e3, 50.0e3/3]
-    dm_rates = [10, 5, 6, 5]
-    transition_widths = [150.0e3, 40.0e3, 15.0e3, 1.0e3]
-    cutoffs = [20.0e3, 10.0e3, 10.0e3, 5.0e3] # bandwidth is double this
-    ripple_dbs = [150.0, 80.0, 35.0, 9.0]
-    scaling_factors = [10.0, 100.0, 100.0, 100.0]
+    rates = [500.0e3, 100.0e3, 50.0e3/3]
+    dm_rates = [5, 6, 5]
+    transition_widths = [40.0e3, 15.0e3, 1.0e3]
+    cutoffs = [10.0e3, 10.0e3, 5.0e3] # bandwidth is double this
+    ripple_dbs = [80.0, 35.0, 9.0]
+    scaling_factors = [100.0, 100.0, 100.0]
     all_stages = []
 
-    for stage in range(0,4):
+    for stage in range(0,3):
         filter_taps = list(scaling_factors[stage] * create_firwin_filter_by_attenuation(rates[stage], transition_widths[stage], cutoffs[stage], ripple_dbs[stage]))
         all_stages.append(DecimationStage(stage, rates[stage], dm_rates[stage], filter_taps))
 
-    return (DecimationScheme(5.0e6, 10.0e3/3, stages=all_stages))
+    return (DecimationScheme(0.5e6, 10.0e3/3, stages=all_stages))
 
 
 def calculate_num_filter_taps(sampling_freq, trans_width, k):

--- a/experiment_prototype/experiment_prototype.py
+++ b/experiment_prototype/experiment_prototype.py
@@ -275,7 +275,7 @@ possible_averaging_methods = frozenset(['mean', 'median'])
 possible_scheduling_modes = frozenset(['common', 'special', 'discretionary'])
 default_rx_bandwidth = 5.0e6
 default_output_rx_rate = 10.0e3/3
-transition_bandwidth = 750.0e3
+transition_bandwidth = 37500.0
 
 class ExperimentPrototype(object):
     """

--- a/experiments/normalscan_low_bw.py
+++ b/experiments/normalscan_low_bw.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python
+
+# write an experiment that creates a new control program.
+
+import sys
+import os
+
+BOREALISPATH = os.environ['BOREALISPATH']
+sys.path.append(BOREALISPATH)
+
+import experiments.superdarn_common_fields as scf
+from experiment_prototype.experiment_prototype import ExperimentPrototype
+
+class Normalscan(ExperimentPrototype):
+
+    def __init__(self, **kwargs):
+        """
+        kwargs:
+
+        freq: int
+
+        """
+        cpid = 151
+        output_rx_rate = 10.0e3/3
+        tx_bandwidth = 0.5e6
+        rx_bandwidth = 0.5e6
+        super(Normalscan, self).__init__(cpid, output_rx_rate, rx_bandwidth, tx_bandwidth)
+
+        if scf.IS_FORWARD_RADAR:
+            beams_to_use = scf.STD_16_FORWARD_BEAM_ORDER
+        else:
+            beams_to_use = scf.STD_16_REVERSE_BEAM_ORDER
+
+        if scf.opts.site_id in ["cly", "rkn", "inv"]:
+            num_ranges = scf.POLARDARN_NUM_RANGES
+        if scf.opts.site_id in ["sas", "pgr", "wal"]:
+            num_ranges = scf.STD_NUM_RANGES
+
+        # default frequency set here
+        freq = 12000.0
+        
+        if kwargs:
+            if 'freq' in kwargs.keys():
+                freq = kwargs['freq']
+        
+        self.printing('Frequency set to {}'.format(freq))
+
+        self.add_slice({  # slice_id = 0, there is only one slice.
+            "pulse_sequence": scf.SEQUENCE_7P,
+            "tau_spacing": scf.TAU_SPACING_7P,
+            "pulse_len": scf.PULSE_LEN_45KM,
+            "num_ranges": num_ranges,
+            "first_range": scf.STD_FIRST_RANGE,
+            "intt": 3500,  # duration of an integration, in ms
+            "beam_angle": scf.STD_16_BEAM_ANGLE,
+            "beam_order": beams_to_use,
+            "scanbound": [i * 3.5 for i in range(len(beams_to_use))], #1 min scan
+            "txfreq" : freq, #kHz
+            "acf": True,
+            "xcf": True,  # cross-correlation processing
+            "acfint": True,  # interferometer acfs
+        })

--- a/usrp_drivers/usrp_driver.cpp
+++ b/usrp_drivers/usrp_driver.cpp
@@ -34,7 +34,7 @@
 
 
 //Delay needed for before any set_time_commands will work.
-#define SET_TIME_COMMAND_DELAY 5e-3 // seconds
+#define SET_TIME_COMMAND_DELAY 15e-3 // seconds
 #define TUNING_DELAY 300e-3 // seconds
 
 // GPS clock variable. Gets updated every time an RX packet is recvd.

--- a/usrp_drivers/usrp_driver.cpp
+++ b/usrp_drivers/usrp_driver.cpp
@@ -37,9 +37,6 @@
 #define SET_TIME_COMMAND_DELAY 5e-3 // seconds
 #define TUNING_DELAY 300e-3 // seconds
 
-// GPS clock variable. Gets updated every time an RX packet is recvd.
-uhd::time_spec_t box_time;
-
 
 /**
  * @brief      Makes a set of vectors of the samples for each TX channel from the driver packet.
@@ -256,9 +253,9 @@ void transmit(zmq::context_t &driver_c, USRP &usrp_d, const DriverOptions &drive
       pulse_ptrs[i] = ptrs;
     }
 
-    // Getting usrp box time to find out when to send samples. box_time continously being updated.
+    // Getting usrp box time to find out when to send samples.
     auto delay = uhd::time_spec_t(SET_TIME_COMMAND_DELAY);
-    auto time_now = box_time;
+    auto time_now = usrp_d.get_current_usrp_time();
     auto sequence_start_time = time_now + delay;
 
     auto seqn_sampling_time = num_recv_samples/rx_rate;
@@ -368,7 +365,7 @@ void transmit(zmq::context_t &driver_c, USRP &usrp_d, const DriverOptions &drive
 
 
 
-    auto end_time = box_time;
+    auto end_time = usrp_d.get_current_usrp_time();
     auto sleep_time = uhd::time_spec_t(seqn_sampling_time) - (end_time-sequence_start_time) + delay;
     // sleep_time is how much longer we need to wait in tx thread before the end of the sampling time
 
@@ -387,7 +384,7 @@ void transmit(zmq::context_t &driver_c, USRP &usrp_d, const DriverOptions &drive
     samples_metadata.set_ringbuffer_size(ringbuffer_size);
     samples_metadata.set_numberofreceivesamples(num_recv_samples);
     samples_metadata.set_sequence_num(sqn_num);
-    auto actual_finish = box_time;
+    auto actual_finish = usrp_d.get_current_usrp_time();
     samples_metadata.set_sequence_time((actual_finish - time_now).get_real_secs());
 
     for (auto &mobo_pins : pin_status_h) {
@@ -494,7 +491,6 @@ void receive(zmq::context_t &driver_c, USRP &usrp_d, const DriverOptions &driver
       start_trigger.send(start_time);
       first_time = false;
     }
-    box_time = meta.time_spec;
     auto error_code = meta.error_code;
 
     switch(error_code) {


### PR DESCRIPTION
My colleague (@alexchartier) discovered an issue where the UHD instance, specifically the transmitter, was throwing "L" errors ("late packet" errors). These errors occur when the UHD packet that arrives at the USRP's FPGA indicates a transmission time that occurs in the past. Note that this is different than the UHD underflow "U" error.

I looked into what could be causing this in the `usrp_driver.cpp` file and found that `box_time`, which is the variable that gives the transmitter the current USRP time, is a shared variable between two threads with no mutex or atomic protections. In general, this will give undefined behavior, meaning let's say 99% of the time the variable could be getting updated with the proper value, but 1% of the time could be getting set with an erroneous value. When that value is not set correctly our transmit packet will have a value that occurs in the past or far far into the future (could be a really small value or really large value).

We can side step this problem of synchronizing a variable between threads entirely by just having the transmitter directly fetch the current USRP time. This resolved the late packet errors he was experiencing, his testing was performed over several days of runtime to ensure the correction.