### PR TITLE
Modify the standard 16 beam angles 

### DIFF
--- a/docs/source/building_an_experiment.rst
+++ b/docs/source/building_an_experiment.rst
@@ -232,9 +232,8 @@ beam_angle *required*
     needed to write the beam_order list. This is like a mapping of beam number (list
     index) to beam direction off boresight. Typically you can use the radar's common
     beam angle list. For example, at Saskatoon site the beam angles are a standard
-    16-beam list: [-26.25, -22.75, -19.25, -15.75, -12.25, -8.75,
-            -5.25, -1.75, 1.75, 5.25, 8.75, 12.25, 15.75, 19.25, 22.75,
-            26.25]
+    16-beam list: [-24.3, -21.06, -17.82, -14.58, -11.34, -8.1, -4.86,
+                     -1.62, 1.62, 4.86, 8.1, 11.34, 14.58, 21.06, 24.3]
 
 beam_order *required*
     beam numbers written in order of preference, one element in this list corresponds to
@@ -383,9 +382,8 @@ An example of adding a slice to your experiment is as follows::
             "num_ranges": 75,  # range gates
             "first_range": 180,  # first range gate, in km
             "intt": 3500,  # duration of an integration, in ms
-            "beam_angle": [-26.25, -22.75, -19.25, -15.75, -12.25, -8.75,
-                           -5.25, -1.75, 1.75, 5.25, 8.75, 12.25, 15.75, 19.25, 22.75,
-                           26.25],
+            "beam_angle": [-24.3, -21.06, -17.82, -14.58, -11.34, -8.1, -4.86,
+                     -1.62, 1.62, 4.86, 8.1, 11.34, 14.58, 21.06, 24.3],
             "beam_order": [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
             "scanbound": [i * 3.5 for i in range(len(beams_to_use))], #1 min scan
             "txfreq" : 10500, #kHz

--- a/experiments/superdarn_common_fields.py
+++ b/experiments/superdarn_common_fields.py
@@ -5,6 +5,7 @@ BOREALISPATH = os.environ['BOREALISPATH']
 sys.path.append(BOREALISPATH)
 
 from utils.experiment_options.experimentoptions import ExperimentOptions
+opts = ExperimentOptions()
 
 # TODO: We should protect these values from changing, I noticed during testing that I used a
 # TODO: call to reverse() on one and it affected the rest of the testing afterwards
@@ -47,10 +48,7 @@ STD_8P_LAG_TABLE = [[ 0, 0],
 PULSE_LEN_45KM = 300 #us
 PULSE_LEN_15KM = 100 #us
 
-STD_16_BEAM_ANGLE = [-26.25, -22.75, -19.25, -15.75, -12.25, -8.75,
-            -5.25, -1.75, 1.75, 5.25, 8.75, 12.25, 15.75, 19.25, 22.75,
-            26.25]
-
+STD_16_BEAM_ANGLE = [(float(opts.beam_sep) * (beam_dir - 15/2)) for beam_dir in range(0, 16)]
 
 STD_NUM_RANGES = 75
 POLARDARN_NUM_RANGES = 75
@@ -60,7 +58,7 @@ STD_16_FORWARD_BEAM_ORDER = [0, 1, 2 , 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 
 STD_16_REVERSE_BEAM_ORDER = [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
 
 # Scanning directions here for now.
-opts = ExperimentOptions()
+
 IS_FORWARD_RADAR = IS_REVERSE_RADAR = False
 if opts.site_id in ["sas", "rkn", "inv"]:
     IS_FORWARD_RADAR = True

--- a/utils/experiment_options/experimentoptions.py
+++ b/utils/experiment_options/experimentoptions.py
@@ -138,8 +138,7 @@ class ExperimentOptions:
         self._geo_long = params[4]  # decimal degrees, W = negative
         self._altitude = params[5]  # metres
         self._boresight = params[6]  # degrees from geographic north, CCW = negative.
-        self._beam_sep = params[7]  # degrees TODO is this necessary, or is this a min. - for
-        # post-processing software in RST? check with others.
+        self._beam_sep = params[7]  # degrees
         self._velocity_sign = params[8]  # +1.0 or -1.0
         self._analog_rx_attenuator = params[9]  # dB
         self._tdiff = params[10] # ns
@@ -429,8 +428,7 @@ class ExperimentOptions:
 
     @property
     def beam_sep(self):
-        return self._beam_sep  # degrees TODO is this necessary, or is this a min. - for
-                        # post-processing software in RST? check with others.
+        return self._beam_sep  # degrees
 
     @property
     def velocity_sign(self):


### PR DESCRIPTION
Modify the standard 16 beam angles to utilize the hdw.dat file's values (typically 3.24 degrees) instead of hard-coded 3.5 degree azimuth beam separations.

This should be be tested and merged at the same time that the superdarn hdw.dat file repository is updated to add lines for when the beam separation was 3.5 degrees