### PR TITLE
Multifreq widebeam

### DIFF
--- a/experiment_prototype/scan_classes/sequences.py
+++ b/experiment_prototype/scan_classes/sequences.py
@@ -230,7 +230,7 @@ class Sequence(ScanClassBase):
         # slice a higher power weighting if you wanted)
 
         # This conditional block checks whether the slices interfaced in this sequence use any of
-        # the same antennas. If they do, the power should not be divided, because no single
+        # the same antennas. If they don't, the power should not be divided, because no single
         # N200 is being asked to deliver power from multiple slices. If some antennas are being
         # shared, then the power divider defaults to the normal division (divide by the maximum
         # number of overlapping pulses).

--- a/experiments/multifreq_widebeam.py
+++ b/experiments/multifreq_widebeam.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python
+
+# A simultaneous multifrequency widebeam mode.
+# This experiment uses two pairs of adjacent antennas for transmitting,
+# with each pair operating on its own frequency.
+# The mode has zero phase (no beams) and receives on all antennas.
+# There is no scan boundary, it simply sounds for 3.5 seconds at a time.
+# It does not generate correlations and only produces antennas_iq data.
+
+# Requested by Dr. Pasha Ponomarenko April 2022
+import copy
+import sys
+import os
+
+BOREALISPATH = os.environ['BOREALISPATH']
+sys.path.append(BOREALISPATH)
+
+import experiments.superdarn_common_fields as scf
+from experiment_prototype.experiment_prototype import ExperimentPrototype
+
+
+class MultifreqWidebeam(ExperimentPrototype):
+
+    def __init__(self, **kwargs):
+        """
+        kwargs:
+
+        freq: int
+
+        """
+        cpid = 3712
+
+        if scf.opts.site_id in ["cly", "rkn", "inv"]:
+            num_ranges = scf.POLARDARN_NUM_RANGES
+        if scf.opts.site_id in ["sas", "pgr"]:
+            num_ranges = scf.STD_NUM_RANGES
+
+        tx_freq_1 = scf.COMMON_MODE_FREQ_1
+        tx_freq_2 = scf.COMMON_MODE_FREQ_2
+
+        if kwargs:
+            if 'freq1' in kwargs.keys():
+                tx_freq_1 = int(kwargs['freq1'])
+
+            if 'freq2' in kwargs.keys():
+                tx_freq_2 = int(kwargs['freq2'])
+
+        slice_1 = {  # slice_id = 0, the first slice
+            "pulse_sequence": scf.SEQUENCE_7P,
+            "tau_spacing": scf.TAU_SPACING_7P,
+            "pulse_len": scf.PULSE_LEN_45KM,
+            "num_ranges": num_ranges,
+            "first_range": scf.STD_FIRST_RANGE,
+            "intt": 3500,  # duration of an integration, in ms
+            "beam_angle": [0],
+            "beam_order": [0],
+            "txfreq": tx_freq_1,  # kHz
+            "tx_antennas": [6, 7],  # Using two tx antennas from the middle of array
+        }
+
+        slice_2 = copy.deepcopy(slice_1)    # slice_id = 1, the second slice
+        slice_2['txfreq'] = tx_freq_2
+        slice_2['tx_antennas'] = [8, 9]     # Use separate pair of antennas near middle of array
+
+        list_of_slices = [slice_1, slice_2]
+        sum_of_freq = 0
+        for slice in list_of_slices:
+            sum_of_freq += slice['txfreq']  # kHz, oscillator mixer frequency on the USRP for TX
+        rxctrfreq = txctrfreq = int(sum_of_freq / len(list_of_slices))
+
+        super().__init__(cpid, txctrfreq=txctrfreq, rxctrfreq=rxctrfreq,
+                         comment_string='Simultaneous multifrequency widebeam')
+
+        self.add_slice(slice_1)
+
+        self.add_slice(slice_2, interfacing_dict={0: 'PULSE'})

--- a/experiments/multifreq_widebeam.py
+++ b/experiments/multifreq_widebeam.py
@@ -26,7 +26,8 @@ class MultifreqWidebeam(ExperimentPrototype):
         """
         kwargs:
 
-        freq: int
+        freq1: int, first transmit frequency - kHz
+        freq2: int, second transmit frequency - kHz
 
         """
         cpid = 3712

--- a/experiments/multifreq_widebeam.py
+++ b/experiments/multifreq_widebeam.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+# Copyright SuperDARN Canada 2022
 # A simultaneous multifrequency widebeam mode.
 # This experiment uses two pairs of adjacent antennas for transmitting,
 # with each pair operating on its own frequency.

--- a/sample_building/sample_building.py
+++ b/sample_building/sample_building.py
@@ -637,4 +637,4 @@ def calculate_first_rx_sample_time(first_pulse_num_samples_with_tr, txrate):
 
     first_rx_sample_index = int(first_pulse_num_samples_with_tr/2)
     first_rx_sample_time = float(first_rx_sample_index)/txrate
-    return first_rx_sample_time
+    return int(first_rx_sample_time)

--- a/sample_building/sample_building.py
+++ b/sample_building/sample_building.py
@@ -637,4 +637,4 @@ def calculate_first_rx_sample_time(first_pulse_num_samples_with_tr, txrate):
 
     first_rx_sample_index = int(first_pulse_num_samples_with_tr/2)
     first_rx_sample_time = float(first_rx_sample_index)/txrate
-    return int(first_rx_sample_time)
+    return first_rx_sample_time


### PR DESCRIPTION
* Fixed small bug with type errors in the protobuf packet

* Fixed power splitting issue when the slices don't use the same antennas.

This branch has been tested with the new experiment on our lab setup and works as expected. There are two different frequencies operating each on their own set of antennas (N200s) with no power splitting as the antenna groups are mutually exclusive. I also tested the case when the antenna groups were not mutually exclusive, and the power was correctly split for all slices. 