### PR TITLE
Interfacing refactor

### DIFF
--- a/docs/source/building_an_experiment.rst
+++ b/docs/source/building_an_experiment.rst
@@ -310,7 +310,7 @@ rx_main_antennas *defaults*
 scanbound *defaults*
     A list of seconds past the minute for averaging periods in a scan to align to. Defaults
     to None, not required. If you set this, you will want to ensure that there is a slightly 
-    larger amount of time in the scan boundaries than the integration time set for the slice. 
+    larger amount of time in the scan boundaries than the averaging period set for the slice. 
     For example, if you want to align integration times at the 3 second marks, you may want to
     have a set integration time of ~2.9s to ensure that the experiment will start on time. 
     Typically 50ms difference will be enough. This is especially important for the last averaging

--- a/docs/source/building_an_experiment.rst
+++ b/docs/source/building_an_experiment.rst
@@ -63,25 +63,25 @@ from highest level to lowest level:
 
    There are no requirements for slices interfaced in this manner.
 
-2. **INTTIME**
+2. **AVEPERIOD**
 
-   This type of interfacing allows for one slice to run its integration period (also known as integration time or averaging period), before switching to another slice's integration period. This type of interface effectively creates an interleaving scan where the scans for multiple slices are run 'at the same time', by interleaving the integration times.
+   This type of interfacing allows for one slice to run its averaging period (also known as integration time or integration period), before switching to another slice's integration period. This type of interface effectively creates an interleaving scan where the scans for multiple slices are run 'at the same time', by interleaving the averaging periods.
    
    Slices which are interfaced in this manner must share:  
     - the same SCANBOUND value.
 
-3. **INTEGRATION**
+3. **SEQUENCE**
    
-   Integration interfacing allows for pulse sequences defined in the slices to alternate between each other within a single integration period. It's important to note that data from a single slice is averaged only with other data from that slice. So in this case, the integration period is running two slices and can produce two averaged datasets, but the sequences (integrations) within the integration period are interleaved.
+   SEQUENCE interfacing allows for pulse sequences defined in the slices to alternate between each other within a single averaging period. It's important to note that data from a single slice is averaged only with other data from that slice. So in this case, the averaging period is running two slices and can produce two averaged datasets, but the sequences within the averaging period are interleaved.
    
    Slices which are interfaced in this manner must share:  
     - the same SCANBOUND value.
     - the same INTT or INTN value.
     - the same BEAM_ORDER length (scan length)
 
-4. **PULSE**
+4. **CONCURRENT**
    
-   Pulse interfacing allows for pulse sequences to be run together concurrently. Slices will have their pulse sequences layered together so that the data transmits at the same time. For example, slices of different frequencies can be mixed simultaneously, and slices of different pulse sequences can also run together at the cost of having more blanked samples. When slices are interfaced in this way the radar is truly transmitting and receiving the slices simultaneously.
+   CONCURRENT interfacing allows for pulse sequences to be run together concurrently. Slices will have their pulse sequences layered together so that the data transmits at the same time. For example, slices of different frequencies can be mixed simultaneously, and slices of different pulse sequences can also run together at the cost of having more blanked samples. When slices are interfaced in this way the radar is truly transmitting and receiving the slices simultaneously.
    
    Slices which are interfaced in this manner must share:  
     - the same SCANBOUND value.
@@ -94,15 +94,15 @@ Slice Interfacing Examples
 Let's look at some examples of common experiments that can easily be separated into multiple slices. 
 In these examples, the ⟳ means that the averaging period is repeated multiple times in a scan, and the different slices are colour coded.
 
-In a CUTLASS-style experiment, the pulse in the sequence is actually two pulses of differing transmit frequency. This is a 'quasi'-simultaneous multi-frequency experiment where the frequency changes in the middle of the pulse. To build this experiment, two slices can be PULSE interfaced. The pulses from both slices are combined into a single set of transmitted samples for that sequence and samples received from those sequences are used for both slices (filtering the raw data separates the frequencies). 
+In a CUTLASS-style experiment, the pulse in the sequence is actually two pulses of differing transmit frequency. This is a 'quasi'-simultaneous multi-frequency experiment where the frequency changes in the middle of the pulse. To build this experiment, two slices can be CONCURRENT interfaced. The pulses from both slices are combined into a single set of transmitted samples for that sequence and samples received from those sequences are used for both slices (filtering the raw data separates the frequencies).
 
 .. image:: img/cutlass.png
    :width: 800px
    :alt: CUTLASS-style experiment slice interfacing 
    :align: center
 
-In a themisscan experiment, a single beam is interleaved with a full scan. The beam_order can be unique to different slices, and these slices could be INTTIME interfaced to separate the camping beam data from the full scan,
-if desired. With INTTIME interfacing, one averaging period of one slice will be followed by an averaging period of another, and so on. The averaging periods are interleaved. The resulting experiment runs beams 0, 7, 1, 7, etc. 
+In a themisscan experiment, a single beam is interleaved with a full scan. The beam_order can be unique to different slices, and these slices could be AVEPERIOD interfaced to separate the camping beam data from the full scan,
+if desired. With AVEPERIOD interfacing, one averaging period of one slice will be followed by an averaging period of another, and so on. The averaging periods are interleaved. The resulting experiment runs beams 0, 7, 1, 7, etc.
 
 .. image:: img/themisscan.png
    :width: 800px
@@ -118,7 +118,7 @@ followed by a full scan of slice 1, and then the process repeats.
    :align: center
 
 
-Here's a theoretical example showing all types of interfacing. In this example, slices 0 and 1 are PULSE interfaced. Slices 0 and 2 are INTEGRATION interfaced. Slices 0 and 3 are INTTIME interfaced. Slices 0 and 4 are SCAN interfaced.
+Here's a theoretical example showing all types of interfacing. In this example, slices 0 and 1 are CONCURRENT interfaced. Slices 0 and 2 are SEQUENCE interfaced. Slices 0 and 3 are AVEPERIOD interfaced. Slices 0 and 4 are SCAN interfaced.
 
 .. image:: img/one-experiment-all-interfacing-types.png
    :width: 800px
@@ -308,19 +308,19 @@ rx_main_antennas *defaults*
     given max number from config.
 
 scanbound *defaults*
-    A list of seconds past the minute for integration times in a scan to align to. Defaults
+    A list of seconds past the minute for averaging periods in a scan to align to. Defaults
     to None, not required. If you set this, you will want to ensure that there is a slightly 
     larger amount of time in the scan boundaries than the integration time set for the slice. 
     For example, if you want to align integration times at the 3 second marks, you may want to
     have a set integration time of ~2.9s to ensure that the experiment will start on time. 
-    Typically 50ms difference will be enough. This is especially important for the last integration
-    time in the scan, as the experiment will always wait for the next scan start boundary
+    Typically 50ms difference will be enough. This is especially important for the last averaging
+    period in the scan, as the experiment will always wait for the next scan start boundary
     (potentially causing a minute of downtime). You could also just leave a small amount
     of downtime at the end of the scan.
 
 seqoffset *defaults*
     offset in us that this slice's sequence will begin at, after the start of the sequence.
-    This is intended for PULSE interfacing, when you want multiple slices' pulses in one sequence
+    This is intended for CONCURRENT interfacing, when you want multiple slices' pulses in one sequence
     you can offset one slice's sequence from the other by a certain time value so as to not run both
     frequencies in the same pulse, etc. Default is 0 offset.
 

--- a/docs/source/building_an_experiment.rst
+++ b/docs/source/building_an_experiment.rst
@@ -311,7 +311,7 @@ scanbound *defaults*
     A list of seconds past the minute for averaging periods in a scan to align to. Defaults
     to None, not required. If you set this, you will want to ensure that there is a slightly 
     larger amount of time in the scan boundaries than the averaging period set for the slice. 
-    For example, if you want to align integration times at the 3 second marks, you may want to
+    For example, if you want to align averaging periods at the 3 second marks, you may want to
     have a set integration time of ~2.9s to ensure that the experiment will start on time. 
     Typically 50ms difference will be enough. This is especially important for the last averaging
     period in the scan, as the experiment will always wait for the next scan start boundary

--- a/docs/source/building_an_experiment.rst
+++ b/docs/source/building_an_experiment.rst
@@ -312,7 +312,7 @@ scanbound *defaults*
     to None, not required. If you set this, you will want to ensure that there is a slightly 
     larger amount of time in the scan boundaries than the averaging period set for the slice. 
     For example, if you want to align averaging periods at the 3 second marks, you may want to
-    have a set integration time of ~2.9s to ensure that the experiment will start on time. 
+    have a set averaging period of ~2.9s to ensure that the experiment will start on time. 
     Typically 50ms difference will be enough. This is especially important for the last averaging
     period in the scan, as the experiment will always wait for the next scan start boundary
     (potentially causing a minute of downtime). You could also just leave a small amount

--- a/docs/source/building_an_experiment.rst
+++ b/docs/source/building_an_experiment.rst
@@ -65,7 +65,7 @@ from highest level to lowest level:
 
 2. **AVEPERIOD**
 
-   This type of interfacing allows for one slice to run its averaging period (also known as integration time or integration period), before switching to another slice's integration period. This type of interface effectively creates an interleaving scan where the scans for multiple slices are run 'at the same time', by interleaving the averaging periods.
+   AVEPERIOD interfacing allows for one slice to run its averaging period (also known as integration time or integration period), before switching to another slice's averaging period. This type of interface effectively creates an interleaving scan where the scans for multiple slices are run 'at the same time', by interleaving the averaging periods.
    
    Slices which are interfaced in this manner must share:  
     - the same SCANBOUND value.

--- a/experiment_prototype/scan_classes/averaging_periods.py
+++ b/experiment_prototype/scan_classes/averaging_periods.py
@@ -93,19 +93,19 @@ class AveragingPeriod(ScanClassBase):
         if self.intt is not None:  # intt has priority over intn
             for slice_id in self.slice_ids:
                 if self.slice_dict[slice_id]['intt'] != self.intt:
-                    errmsg = "Slices {} and {} are INTEGRATION or PULSE interfaced and do not have the" \
+                    errmsg = "Slices {} and {} are SEQUENCE or CONCURRENT interfaced and do not have the" \
                              " same Averaging Period duration intt".format(self.slice_ids[0], slice_id)
                     raise ExperimentException(errmsg)
         elif self.intn is not None:
             for slice_id in self.slice_ids:
                 if self.slice_dict[slice_id]['intn'] != self.intn:
-                    errmsg = "Slices {} and {} are INTEGRATION or PULSE interfaced and do not have the" \
+                    errmsg = "Slices {} and {} are SEQUENCE or CONCURRENT interfaced and do not have the" \
                              " same NAVE goal intn".format(self.slice_ids[0], slice_id)
                     raise ExperimentException(errmsg)
 
         for slice_id in self.slice_ids: 
             if len(self.slice_dict[slice_id]['beam_order']) != len(self.slice_dict[self.slice_ids[0]]['beam_order']):
-                errmsg = "Slices {} and {} are INTEGRATION or PULSE interfaced but do not have the" \
+                errmsg = "Slices {} and {} are SEQUENCE or CONCURRENT interfaced but do not have the" \
                          " same number of integrations in their beam order" \
                          .format(self.slice_ids[0], slice_id)
                 raise ExperimentException(errmsg)
@@ -113,7 +113,7 @@ class AveragingPeriod(ScanClassBase):
 
         # NOTE: Do not need beam information inside the AveragingPeriod, this is in Scan.
 
-        # Determine how this averaging period is made by separating out the INTEGRATION interfaced.
+        # Determine how this averaging period is made by separating out the SEQUENCE interfaced.
         self.nested_slice_list = self.get_sequence_slice_ids()
         self.sequences = []
 
@@ -142,9 +142,9 @@ class AveragingPeriod(ScanClassBase):
 
         integ_combos = []
 
-        # Remove INTEGRATION combos as we are trying to separate those.
+        # Remove SEQUENCE combos as we are trying to separate those.
         for k, interface_type in self.interface.items():  # TODO make example
-            if interface_type == "PULSE":
+            if interface_type == "CONCURRENT":
                 integ_combos.append(list(k))
 
         combos = self.slice_combos_sorter(integ_combos, self.slice_ids)

--- a/experiment_prototype/scan_classes/scan_class_base.py
+++ b/experiment_prototype/scan_classes/scan_class_base.py
@@ -118,8 +118,8 @@ class ScanClassBase(object):
         """
         Sort keys of a list of combinations so that keys only appear once in the list.
 
-        This function modifes the input list_of_combos so that all slices that are
-        associated are associated in the same list. For example, if input is
+        This function modifies the input list_of_combos so that all slices that are
+        associated, are associated in the same list. For example, if input is
         list_of_combos = [[0,1], [0,2], [0,4], [1,4], [2,4]] and all_keys = [0,1,2,4,5]
         then the output should be [[0,1,2,4], [5]]. This is used to get the slice
         dictionary for nested class instances. In the above example, we would then have
@@ -147,26 +147,28 @@ class ScanClassBase(object):
                 scan_j = scan_i + 1  # j: iterates through the other elements of list_of_combos, to combine them into
                 # the first, i, if they are in fact part of the same scan.
                 while scan_j < len(list_of_combos):
-                    if list_of_combos[scan_i][slice_id_k] == list_of_combos[scan_j][0]:  # if an element (slice_id) inside
-                        # the i scan is the same as a slice_id in the j scan (somewhere further in the list_of_combos),
-                        # then we need to combine that j scan into the i scan. We only need to check the first element
-                        # of the j scan because list_of_combos has been sorted and we know the first slice_id in the scan
-                        # is less than the second slice id.
+                    if list_of_combos[scan_i][slice_id_k] == list_of_combos[scan_j][0]:
+                        # if an element (slice_id) inside the i scan is the same as a slice_id in the j scan (somewhere
+                        # further in the list_of_combos), then we need to combine that j scan into the i scan. We only
+                        # need to check the first element of the j scan because list_of_combos has been sorted and we
+                        # know the first slice_id in the scan is less than the second slice id.
                         add_n_slice_id = list_of_combos[scan_j][1]  # the slice_id to add to the i scan from the j scan.
                         list_of_combos[scan_i].append(add_n_slice_id)
                         # Combine the indices if there are 3+ slices combining in same scan
-                        for m in range(0, len(list_of_combos[scan_i]) - 1):  # if we have added z to scan_i, such that
-                            # scan_i is now [x,y,z], we now have to remove from the list_of_combos list [x,z], and [y,z].
+                        for m in range(0, len(list_of_combos[scan_i]) - 1):
+                            # if we have added z to scan_i, such that scan_i is now [x,y,z], we now have to remove from
+                            # the list_of_combos list [x,z], and [y,z].
                             # If x,z existed as SCAN but y,z did not, we have an error.
+
                             # Try all values in list_of_combos[i] except the last value, which is = to add_n.
                             try:
                                 list_of_combos.remove([list_of_combos[scan_i][m], add_n_slice_id])
                                 # list_of_combos[j][1] is the known last value in list_of_combos[i]
                             except ValueError:
-                                # This error would occur if e.g. you had set [x,y] and [x,z] to PULSE but [y,z] to
+                                # This error would occur if e.g. you had set [x,y] and [x,z] to CONCURRENT but [y,z] to
                                 # SCAN. This means that we couldn't remove the scan_combo y,z from the list because it
-                                # was not added to list_of_combos because it wasn't a scan type, so the interfacing would
-                                # not make sense (conflict).
+                                # was not added to list_of_combos because it wasn't a scan type, so the interfacing
+                                # would not make sense (conflict).
                                 errmsg = 'Interfacing not Valid: exp_slice {} and exp_slice {} are combined in-scan and do not \
                                     interface the same with exp_slice {}'.format(
                                     list_of_combos[scan_i][m],
@@ -175,14 +177,14 @@ class ScanClassBase(object):
                                 raise ExperimentException(errmsg)
                         scan_j = scan_j - 1
                         # This means that the former list_of_combos[j] has been deleted and there are new values at
-                        #   index j, so decrement before incrementing in while.
+                        #   index j, so decrement before incrementing in the while loop.
                         # The above for loop will delete more than one element of list_of_combos (min 2) but the
                         # while scan_j < len(list_of_combos) will reevaluate the length of list_of_combos.
                     scan_j = scan_j + 1
                 slice_id_k = slice_id_k + 1  # if interfacing has been properly set up, the loop will only ever find
-                # elements to add to scan_i when slice_id_k = 0. If there were errors though (ex. x,y and y,z = PULSE
-                # but x,z did not) then iterating through the slice_id elements will allow us to find the
-                # error.
+                # elements to add to scan_i when slice_id_k = 0. If there were errors though
+                # (ex. x,y and y,z = CONCURRENT but x,z did not) then iterating through the slice_id elements will allow
+                # us to find the error.
             scan_i = scan_i + 1  # At this point, all elements in the just-finished scan_i will not be found anywhere
             #  else in list_of_combos.
 

--- a/experiment_prototype/scan_classes/scan_class_base.py
+++ b/experiment_prototype/scan_classes/scan_class_base.py
@@ -118,8 +118,8 @@ class ScanClassBase(object):
         """
         Sort keys of a list of combinations so that keys only appear once in the list.
 
-        This function modifies the input list_of_combos so that all slices that are
-        associated, are associated in the same list. For example, if input is
+        This function modifies the input list_of_combos so that all associated
+        slices are in the same list. For example, if input is
         list_of_combos = [[0,1], [0,2], [0,4], [1,4], [2,4]] and all_keys = [0,1,2,4,5]
         then the output should be [[0,1,2,4], [5]]. This is used to get the slice
         dictionary for nested class instances. In the above example, we would then have

--- a/experiment_prototype/scan_classes/scans.py
+++ b/experiment_prototype/scan_classes/scans.py
@@ -42,13 +42,13 @@ class Scan(ScanClassBase):
         for slice_id in self.slice_ids:
             if self.slice_dict[slice_id]['scanbound'] != self.scanbound:
                 errmsg = "Scan boundary not the same between slices {} and {}" \
-                         " for INTTIME or PULSE interfaced slices".format(self.slice_ids[0], slice_id)
+                         " for SEQUENCE or CONCURRENT interfaced slices".format(self.slice_ids[0], slice_id)
                 raise ExperimentException(errmsg)
 
-        # NOTE: for now we assume that when INTTIME combined, the AveragingPeriods of the various slices in the scan are
-        #   just interleaved 1 then the other.
+        # NOTE: for now we assume that when AVEPERIOD combined, the AveragingPeriods of the various slices in the scan
+        # are just interleaved 1 then the other.
 
-        # Create a dictionary of beam directions for slice_id #
+        # Create a dictionary of beam directions for slice_id
         self.beamdir = {}
         self.scan_beams = {}
         for slice_id in self.slice_ids:
@@ -100,20 +100,20 @@ class Scan(ScanClassBase):
         intt_combos = []
 
         for k, interface_value in self.interface.items():
-            if (interface_value == "PULSE" or interface_value == "INTEGRATION"):
+            if interface_value == "CONCURRENT" or interface_value == "SEQUENCE":
                 intt_combos.append(list(k))
         # Inside the scan, we have a subset of the interface dictionary including all combinations
-        # of slice_id that are included in this Scan instance. They could be interfaced INTTIME,
-        # INTEGRATION, or PULSE. We want to remove all of the INTTIME combinations as we want to
-        # eventually have a list of lists (combos) that is of length = # of INTTIMEs in the scan,
-        # with all slices included in the inttimes inside the inner lists.
+        # of slice_id that are included in this Scan instance. They could be interfaced AVEPERIOD,
+        # SEQUENCE, or CONCURRENT. We want to remove all of the AVEPERIOD combinations as we want to
+        # eventually have a list of lists (combos) that is of length = # of AVEPERIODs in the scan,
+        # with all slices included in the averaging periods inside the inner lists.
 
-        # TODO make example and diagram
+        # TODO(Remington): make example and diagram
 
         combos = self.slice_combos_sorter(intt_combos, self.slice_ids)
 
         if __debug__:
-            print("Inttime slice id list: {}".format(combos))
+            print("AvePeriod slice id list: {}".format(combos))
 
         return combos
 
@@ -136,7 +136,7 @@ class Scan(ScanClassBase):
         # Add the beam order and beam direction information that is necessary for
         # AveragingPeriods specifically.
         for params, inttime_list in zip(params_list, self.nested_slice_list):
-            # Make sure the number of inttimes (as determined by length of slice['scan']
+            # Make sure the number of averaging periods (as determined by length of slice['scan'])
             # is the same for slices combined in the averaging period.
             self.nested_beamorder = {}
             self.nested_beamdir = {}

--- a/experiment_prototype/scan_classes/scans.py
+++ b/experiment_prototype/scan_classes/scans.py
@@ -42,7 +42,7 @@ class Scan(ScanClassBase):
         for slice_id in self.slice_ids:
             if self.slice_dict[slice_id]['scanbound'] != self.scanbound:
                 errmsg = "Scan boundary not the same between slices {} and {}" \
-                         " for SEQUENCE or CONCURRENT interfaced slices".format(self.slice_ids[0], slice_id)
+                         " for AVEPERIOD or CONCURRENT interfaced slices".format(self.slice_ids[0], slice_id)
                 raise ExperimentException(errmsg)
 
         # NOTE: for now we assume that when AVEPERIOD combined, the AveragingPeriods of the various slices in the scan

--- a/experiments/2multifsound.py
+++ b/experiments/2multifsound.py
@@ -58,5 +58,5 @@ class TwoMultifsound(ExperimentPrototype):
 
         self.add_slice(slice_1)
 
-        self.add_slice(slice_2, interfacing_dict={0: 'PULSE'})
+        self.add_slice(slice_2, interfacing_dict={0: 'CONCURRENT'})
 

--- a/experiments/epopsound_one_beam.py
+++ b/experiments/epopsound_one_beam.py
@@ -107,7 +107,7 @@ class Epopsound(ExperimentPrototype):
         self.add_slice(slices[0])
         if len(slices) > 1:
             for a_slice in slices[1:]:
-                self.add_slice(a_slice, interfacing_dict={0: 'INTTIME'})
+                self.add_slice(a_slice, interfacing_dict={0: 'AVEPERIOD'})
 
         if marker_period > 0:
             # get the marker slice

--- a/experiments/fullscanstepmode.py
+++ b/experiments/fullscanstepmode.py
@@ -105,5 +105,5 @@ class FullScanStepMode(ExperimentPrototype):
         self.add_slice(slices[0])
         interfacing_dict = {}
         for i in range(1, len(slices)):
-            interfacing_dict[i-1] = 'INTTIME'
+            interfacing_dict[i-1] = 'AVEPERIOD'
             self.add_slice(slices[i], interfacing_dict=interfacing_dict)

--- a/experiments/interleavesound.py
+++ b/experiments/interleavesound.py
@@ -85,5 +85,5 @@ class InterleaveSound(ExperimentPrototype):
         self.add_slice(slices[0])
         self.add_slice(slices[1], {0:'SCAN'})
         for slice_num in range(2,len(slices)):
-            self.add_slice(slices[slice_num], {1:'INTTIME'})
+            self.add_slice(slices[slice_num], {1:'AVEPERIOD'})
 

--- a/experiments/listening_normalscan_2.py
+++ b/experiments/listening_normalscan_2.py
@@ -70,4 +70,4 @@ class ListeningNormalscan2(ExperimentPrototype):
             "acf": True,
             "xcf": True,  # cross-correlation processing
             "acfint": True,  # interferometer acfs
-        }, interfacing_dict={0: 'PULSE'})
+        }, interfacing_dict={0: 'CONCURRENT'})

--- a/experiments/politescan2.py
+++ b/experiments/politescan2.py
@@ -67,4 +67,4 @@ class Politescan2(ExperimentPrototype):
             "acf": True,
             "xcf": True,  # cross-correlation processing
             "acfint": True,  # interferometer acfs
-        }, interfacing_dict={0: 'PULSE'})
+        }, interfacing_dict={0: 'CONCURRENT'})

--- a/experiments/testing_archive/2multifsound.py
+++ b/experiments/testing_archive/2multifsound.py
@@ -93,7 +93,7 @@ class TwoMultifsound(ExperimentPrototype):
 
         self.add_slice(slice_1)
 
-        self.add_slice(slice_2, interfacing_dict={0: 'PULSE'})
+        self.add_slice(slice_2, interfacing_dict={0: 'CONCURRENT'})
 
         # Other things you can change if you wish. You may want to discuss with us about
         # it beforehand.

--- a/experiments/testing_archive/test_bad_interfacing.py
+++ b/experiments/testing_archive/test_bad_interfacing.py
@@ -46,10 +46,10 @@ class TestExperiment(ExperimentPrototype):
         }
         self.add_slice(slice_1)
         # Interfacing between slices is not internally consistent. Here we add slice_2 and slice_3,
-        # with PULSE interfacing to slice_1, but then try to interface 2 and 3 together as SCAN.
+        # with CONCURRENT interfacing to slice_1, but then try to interface 2 and 3 together as SCAN.
         slice_2 = copy.deepcopy(slice_1)
         slice_3 = copy.deepcopy(slice_1)
         slice_3['txfreq'] = scf.COMMON_MODE_FREQ_2 + 1
-        self.add_slice(slice_2, interfacing_dict={0:'PULSE'})
-        self.add_slice(slice_3, interfacing_dict={0:'PULSE', 1:'SCAN'})
+        self.add_slice(slice_2, interfacing_dict={0:'CONCURRENT'})
+        self.add_slice(slice_3, interfacing_dict={0:'CONCURRENT', 1:'SCAN'})
 

--- a/experiments/testing_archive/test_slices_beam_order_bad.py
+++ b/experiments/testing_archive/test_slices_beam_order_bad.py
@@ -46,4 +46,4 @@ class TestExperiment(ExperimentPrototype):
         slice_2 = copy.deepcopy(slice_1)
         slice_2['beam_order'] = [0,1,2,3,4,5,6,7] # Only half of the beams, should fail
         self.add_slice(slice_1)
-        self.add_slice(slice_2, interfacing_dict={0:'PULSE'})
+        self.add_slice(slice_2, interfacing_dict={0:'CONCURRENT'})

--- a/experiments/testing_archive/test_slices_intn_bad.py
+++ b/experiments/testing_archive/test_slices_intn_bad.py
@@ -49,4 +49,4 @@ class TestExperiment(ExperimentPrototype):
         slice_2['intn'] = 10
         slice_1['intn'] = 9  # Different intn targets, should fail
         self.add_slice(slice_1)
-        self.add_slice(slice_2, interfacing_dict={0:'PULSE'})
+        self.add_slice(slice_2, interfacing_dict={0:'CONCURRENT'})

--- a/experiments/testing_archive/test_slices_intt_bad.py
+++ b/experiments/testing_archive/test_slices_intt_bad.py
@@ -56,4 +56,4 @@ class TestExperiment(ExperimentPrototype):
         slice_2['intt'] = 3500
         slice_1['intt'] = 3490  # Different intt durations, should fail
         self.add_slice(slice_1)
-        self.add_slice(slice_2, interfacing_dict={0:'PULSE'})
+        self.add_slice(slice_2, interfacing_dict={0:'CONCURRENT'})

--- a/experiments/testing_archive/test_slices_scanbound_bad.py
+++ b/experiments/testing_archive/test_slices_scanbound_bad.py
@@ -60,5 +60,5 @@ class TestExperiment(ExperimentPrototype):
             "acfint": True,  # interferometer acfs
         }
         self.add_slice(slice_1)
-        self.add_slice(slice_2, interfacing_dict={0: 'PULSE'})
+        self.add_slice(slice_2, interfacing_dict={0: 'CONCURRENT'})
 

--- a/experiments/testing_archive/test_too_many_slices.py
+++ b/experiments/testing_archive/test_too_many_slices.py
@@ -76,8 +76,8 @@ class TestExperiment(ExperimentPrototype):
 
         self.add_slice(slice_1)
         self.add_slice(copy.deepcopy(slice_1)) 
-        self.add_slice(copy.deepcopy(slice_1),interfacing_dict={1: 'INTTIME'}) 
-        self.add_slice(copy.deepcopy(slice_1),interfacing_dict={1: 'INTTIME'}) 
+        self.add_slice(copy.deepcopy(slice_1),interfacing_dict={1: 'AVEPERIOD'})
+        self.add_slice(copy.deepcopy(slice_1),interfacing_dict={1: 'AVEPERIOD'})
         self.add_slice(copy.deepcopy(slice_1),interfacing_dict={0: 'SCAN'}) 
         slices = []
         max_num_slices = int(eo().max_number_of_filter_taps_per_stage/longest_filter_num_taps)
@@ -85,11 +85,11 @@ class TestExperiment(ExperimentPrototype):
         #    max_num_slices))
         for i in range(max_num_slices):
             slices.append(copy.deepcopy(slice_1))
-            self.add_slice(slices[i], interfacing_dict={0: 'PULSE'})
+            self.add_slice(slices[i], interfacing_dict={0: 'CONCURRENT'})
 
         # Just for fun, add a few INTTIME as well
-        self.add_slice(copy.deepcopy(slice_1),interfacing_dict={1: 'INTTIME'}) 
-        self.add_slice(copy.deepcopy(slice_1),interfacing_dict={0: 'INTTIME'}) 
+        self.add_slice(copy.deepcopy(slice_1),interfacing_dict={1: 'AVEPERIOD'})
+        self.add_slice(copy.deepcopy(slice_1),interfacing_dict={0: 'AVEPERIOD'})
         
         # Add a bunch of slices that are scan interfaced, shouldn't have an effect
         self.add_slice(copy.deepcopy(slice_1),interfacing_dict={0: 'SCAN'}) 

--- a/tools/testing_utils/experiments/experiment_tests.csv
+++ b/tools/testing_utils/experiments/experiment_tests.csv
@@ -185,10 +185,10 @@ testing_archive.test_taps_not_list::Filter taps .* of type .* must be a list in 
 testing_archive.test_taps_not_nums::Filter tap .* is not numeric in decimation stage .*
 
 # **** The following 2 tests are from AveragingPeriod class, __init__() method ****
-testing_archive.test_slices_intt_bad::Slices .* and .* are INTEGRATION or PULSE interfaced and do not have the same Averaging Period duration intt
-testing_archive.test_slices_intn_bad::Slices .* and .* are INTEGRATION or PULSE interfaced and do not have the same NAVE goal intn
-testing_archive.test_slices_beam_order_bad::Slices .* and .* are INTEGRATION or PULSE interfaced but do not have the same number of integrations in their beam order
+testing_archive.test_slices_intt_bad::Slices .* and .* are SEQUENCE or CONCURRENT interfaced and do not have the same Averaging Period duration intt
+testing_archive.test_slices_intn_bad::Slices .* and .* are SEQUENCE or CONCURRENT interfaced and do not have the same NAVE goal intn
+testing_archive.test_slices_beam_order_bad::Slices .* and .* are SEQUENCE or CONCURRENT interfaced but do not have the same number of integrations in their beam order
 
 # **** The following test is from Scan class, __init__() method ****
-testing_archive.test_slices_scanbound_bad::Scan boundary not the same between slices .* and .* for INTTIME or PULSE interfaced slices
+testing_archive.test_slices_scanbound_bad::Scan boundary not the same between slices .* and .* for AVEPERIOD or CONCURRENT interfaced slices
 


### PR DESCRIPTION
Refactored the interfacing type names, based on [#302](https://github.com/SuperDARNCanada/borealis/issues/302)

Interfacing types have been changed from:

* SCAN -> SCAN (no change)
* INTTIME -> AVEPERIOD
* INTEGRATION -> SEQUENCE
* PULSE -> CONCURRENT

Additionally, I made some changes in documentation to standardize 'averaging period' as the standard term instead of 'integration time'.