### PR TITLE
Shared memory

### DIFF
--- a/data_write/data_write.py
+++ b/data_write/data_write.py
@@ -189,7 +189,7 @@ class ParseData(object):
                 :param proto_data: protobuf field for parsing
                 """
                 # Open the shared memory
-                shm = shared_memory.SharedMemory(name=proto_data.name)
+                shm = shared_memory.SharedMemory(name=proto_data)
                 acf_data = np.ndarray(data_shape, dtype=np.complex64, buffer=shm.buf)
 
                 # Put the data in the accumulator
@@ -1153,8 +1153,9 @@ class DataWrite(object):
 
             if data_parsing.bfiq_available:
                 for slice_obj in data_parsing.bfiq_accumulator.values():
-                    for arr in slice_obj.values():  # bfiq, intf
-                        for shm_obj in arr['shm']:
+                    for arr in ['main', 'intf']:
+                        arr_dict = slice_obj[arr]
+                        for shm_obj in arr_dict['shm']:
                             shm_obj.close()
                             shm_obj.unlink()
 

--- a/data_write/data_write.py
+++ b/data_write/data_write.py
@@ -172,6 +172,7 @@ class ParseData(object):
         self._lp_status_word = 0b0
 
         self._rawrf_locations = []
+        self._rawrf_num_samps = 0
         self._raw_rf_available = False
 
     def parse_correlations(self):
@@ -352,6 +353,7 @@ class ParseData(object):
 
         if self.processed_data.rf_samples_location:
             self._raw_rf_available = True
+            self._rawrf_num_samps = self.processed_data.rawrf_num_samps
             self._rawrf_locations.append(self.processed_data.rf_samples_location)
 
         # Logical AND to catch any time the GPS may have been unlocked during the integration period
@@ -538,6 +540,15 @@ class ParseData(object):
             TYPE: List of strings.
         """
         return self._rawrf_locations
+
+    @property
+    def rawrf_num_samps(self):
+        """ Gets the number of rawrf samples per antenna.
+
+        Returns:
+            TYPE: int
+        """
+        return self._rawrf_num_samps
 
     @property
     def gps_locked(self):

--- a/rx_signal_processing/SConscript
+++ b/rx_signal_processing/SConscript
@@ -29,5 +29,5 @@ import os
 
 Import('*')
 
-Prog('rx_signal_processing', Glob("./*.c*"), with_libs='utils::utils',
-     LIBS=['protobuf','m','zmq','rt','armadillo'])
+#Prog('rx_signal_processing', Glob("./*.c*"), with_libs='utils::utils',
+#     LIBS=['protobuf','m','zmq','rt','armadillo'])

--- a/rx_signal_processing/dsp.py
+++ b/rx_signal_processing/dsp.py
@@ -82,10 +82,9 @@ class DSP(object):
             self.antennas_iq_samples = xp.asnumpy(self.antennas_iq_samples)
         else:
             self.antennas_iq_samples = antennas_iq_samples
-        self.shared_mem['antennas_iq'] = ant_shm.name
+        self.shared_mem['antennas_iq'] = ant_shm
 
         self.beamform_samples(self.antennas_iq_samples, beam_phases)
-        ant_shm.close()
         
     def create_filters(self, filter_taps, mixing_freqs, rx_rate):
         """
@@ -208,8 +207,7 @@ class DSP(object):
         self.beamformed_samples = np.ndarray(final_shape, dtype=np.complex64, buffer=bf_shm.buf)
         self.beamformed_samples = np.einsum('ijk,ilj->ilk', filtered_samples, beam_phases)
 
-        self.shared_mem['bfiq'] = bf_shm.name
-        bf_shm.close()
+        self.shared_mem['bfiq'] = bf_shm
 
     @staticmethod
     def correlations_from_samples(beamformed_samples_1, beamformed_samples_2, output_sample_rate, slice_index_details):

--- a/rx_signal_processing/dsp.py
+++ b/rx_signal_processing/dsp.py
@@ -2,6 +2,7 @@ import numpy as np
 from scipy.fftpack import fft
 import math
 import time
+from multiprocessing import shared_memory
 
 try:
     import cupy as xp
@@ -197,12 +198,12 @@ class DSP(object):
         :type       beam_phases:       list
 
         """
+        # [num_slices, num_beams, num_antennas]
         beam_phases = np.array(beam_phases)
 
-        # [num_slices, num_antennas, num_samples]
-        # [num_slices, num_beams, num_antennas]
+        # [num_slices, num_beams, num_samples]
         final_shape = (filtered_samples.shape[0], beam_phases.shape[2], filtered_samples.shape[2])
-        final_size = np.complex64.itemsize * filtered_samples.shape[0] * filtered_samples.shape[2] * beam_phases.shape[2]
+        final_size = np.dtype(np.complex64).itemsize * filtered_samples.shape[0] * filtered_samples.shape[2] * beam_phases.shape[2]
         bf_shm = shared_memory.SharedMemory(create=True, size=final_size)
         self.beamformed_samples = np.ndarray(final_shape, dtype=np.complex64, buffer=bf_shm.buf)
         self.beamformed_samples = np.einsum('ijk,ilj->ilk', filtered_samples, beam_phases)

--- a/rx_signal_processing/dsp.py
+++ b/rx_signal_processing/dsp.py
@@ -168,7 +168,7 @@ class DSP(object):
         # We need to force the input into the GPU to be float16, float32, or complex64 so that the einsum result is
         # complex64 and NOT complex128. The GPU is significantly slower (10x++) working with complex128 numbers.
         # We do not require the additional precision.
-        lp_filter = xp.array(lp_filter, dtype=xp.float32)
+        lp_filter = xp.array(lp_filter, dtype=xp.complex64)
         input_samples = windowed_view(input_samples, lp_filter.shape[-1], dm_rate)
 
         # [1, num_taps]

--- a/rx_signal_processing/rx_signal_processing.py
+++ b/rx_signal_processing/rx_signal_processing.py
@@ -118,13 +118,9 @@ def fill_datawrite_proto(processed_data, slice_details, data_outputs):
         for i in range(sd['num_beams']):
             beam = output_data_set.beamformedsamples.add()
             beam.beamnum = i
-
             main_samps = data_outputs['beamformed_m'][sd['slice_num']][i]
-            beam.mainsamples = add_array(main_samps)
-
             try:
                 intf_samps = data_outputs['beamformed_i'][sd['slice_num']][i]
-                beam.intfsamples = add_array(intf_samps)
             except:
                 # No interferometer data
                 pass
@@ -134,7 +130,6 @@ def fill_datawrite_proto(processed_data, slice_details, data_outputs):
             debug_data.stagename = name
 
             all_ant_samps = stage[sd['slice_num']]
-            debug_data.antennadata = add_array(all_ant_samps)
             debug_data.num_antennas = all_ant_samps.shape[0]
             debug_data.num_samps = all_ant_samps.shape[1]
 
@@ -470,6 +465,9 @@ def main():
                 data_outputs['cross_corrs'] = cross_corrs
                 data_outputs['beamformed_i'] = beamformed_i
                 data_outputs['intf_corrs'] = intf_corrs
+
+            shm_names = processed_data.shm_names.add()
+            shm_names = processed_main_samples.shared_mem + processed_intf_samples.shared_mem
 
             fill_datawrite_proto(processed_data, slice_details, data_outputs)
 

--- a/rx_signal_processing/rx_signal_processing.py
+++ b/rx_signal_processing/rx_signal_processing.py
@@ -411,25 +411,25 @@ def main():
                 :param data_array: cp.ndarray or np.ndarray of the data.
                 :param array_name: 'main' or 'intf'. String
                 """
-                shm = shared_memory.SharedMemory(create=True, size=x.nbytes)
-                data = np.ndarray(x.shape, dtype=np.complex64, buffer=shm.buf)
+                shm = shared_memory.SharedMemory(create=True, size=data_array.nbytes)
+                data = np.ndarray(data_array.shape, dtype=np.complex64, buffer=shm.buf)
                 if cupy_available:
                     data[...] = cp.asnumpy(data_array)
                 else:
                     data[...] = data_array
                 holder['{}_shm'.format(array_name)] = shm.name
-                holder['num_samps'] = x.shape[-1]
+                holder['num_samps'] = data_array.shape[-1]
                 shm.close()
             
             # Add the filter stage data if in debug mode
             if __debug__:
-                for i, main_data in enumerate(processed_main_samples[:-1]):
+                for i, main_data in enumerate(processed_main_samples.filter_outputs[:-1]):
                     stage = {}
                     stage['stage_name'] = 'stage_{}'.format(i)
                     debug_data_in_shm(stage, main_data, 'main')
 
                     if sig_options.intf_antenna_count > 0:
-                        intf_data = processed_intf_samples[i]
+                        intf_data = processed_intf_samples.filter_outputs[i]
                         debug_data_in_shm(stage, intf_data, 'intf')
                     stages.append(stage)
 
@@ -472,7 +472,7 @@ def main():
 
             done_filling_rawrf = time.time()
             time_filling_rawrf = (done_filling_rawrf - done_filling_debug) * 1000
-            #pprint("Time to put rawrf in shared memory for #{}: {}ms".format(sequence_num, time_filling_rawrf))
+            pprint("Time to put rawrf in shared memory for #{}: {}ms".format(sequence_num, time_filling_rawrf))
 
             # Add bfiq and correlations data
             beamformed_m = processed_main_samples.beamformed_samples

--- a/rx_signal_processing/rx_signal_processing.py
+++ b/rx_signal_processing/rx_signal_processing.py
@@ -429,14 +429,14 @@ def main():
                         filter_outputs_i.append(processed_intf_samples.antennas_iq_samples)
 
                 else:
-                    filter_outputs_m = processed_main_samples.filter_outputs
+                    filter_outputs_m = [x for x in processed_main_samples.filter_outputs]
                     if sig_options.intf_antenna_count > 0:
-                        filter_outputs_i = processed_intf_samples.filter_outputs
+                        filter_outputs_i = [x for x in processed_intf_samples.filter_outputs]
 
             else:
-                filter_outputs_m = processed_main_samples.antennas_iq_samples
+                filter_outputs_m = [processed_main_samples.antennas_iq_samples]
                 if sig_options.intf_antenna_count > 0:
-                    filter_outputs_i = processed_intf_samples.antennas_iq_samples
+                    filter_outputs_i = [processed_intf_samples.antennas_iq_samples]
 
             if sig_options.intf_antenna_count > 0:
                 filter_outputs = [np.hstack((x, y)) for x, y in zip(filter_outputs_m,

--- a/rx_signal_processing/rx_signal_processing.py
+++ b/rx_signal_processing/rx_signal_processing.py
@@ -81,6 +81,7 @@ def fill_datawrite_proto(processed_data, slice_details, data_outputs):
 
         output_data_set.slice_id = sd['slice_id']
         output_data_set.num_beams = sd['num_beams']
+        output_data_set.num_ranges = sd['num_range_gates']
         output_data_set.num_lags = sd['num_lags']
 
         def add_array(ndarray):
@@ -133,7 +134,7 @@ def fill_datawrite_proto(processed_data, slice_details, data_outputs):
             debug_data.stagename = name
 
             all_ant_samps = stage[sd['slice_num']]
-            debug_data.antennasamples = add_array(all_ant_samps)
+            debug_data.antennadata = add_array(all_ant_samps)
             debug_data.num_antennas = all_ant_samps.shape[0]
             debug_data.num_samps = all_ant_samps.shape[1]
 

--- a/utils/protobuf/processeddata.proto
+++ b/utils/protobuf/processeddata.proto
@@ -17,6 +17,7 @@ message ProcessedData {
     uint32 lp_status_bank_h = 12;
     uint32 agc_status_bank_l = 13;
     uint32 lp_status_bank_l = 14;
+    repeated string shm_names = 15;
 
     message OutputDataSet {
         string mainacf = 1;

--- a/utils/protobuf/processeddata.proto
+++ b/utils/protobuf/processeddata.proto
@@ -19,9 +19,9 @@ message ProcessedData {
     uint32 lp_status_bank_l = 14;
 
     message OutputDataSet {
-        repeated ComplexData mainacf = 1;
-        repeated ComplexData intacf = 2;
-        repeated ComplexData xcf = 3;
+        string mainacf = 1;
+        string intacf = 2;
+        string xcf = 3;
         uint32 num_beams = 4;
         uint32 num_ranges = 5;
         uint32 num_lags = 6;
@@ -30,24 +30,18 @@ message ProcessedData {
         uint32 slice_id = 9;
         repeated float noise_at_freq = 10; //TODO fill and parse
 
-
         message BeamData {
             uint32 beamnum = 1;
-            repeated ComplexData mainsamples = 2;
-            repeated ComplexData intfsamples = 3;
+            string mainsamples = 2;
+            string intfsamples = 3;
+            uint32 num_samps = 4;
         }
 
         message DebugData {
             string stagename = 1;
-            repeated AntennaData antennadata = 2;
-            message AntennaData {
-                repeated ComplexData antennasamples = 1;
-            }
-        }
-
-        message ComplexData {
-            float real = 1;
-            float imag = 2;
+            string antennadata = 2;
+            uint32 num_antennas = 3;
+            uint32 num_samps = 4;
         }
     }
 }

--- a/utils/protobuf/processeddata.proto
+++ b/utils/protobuf/processeddata.proto
@@ -22,6 +22,7 @@ message ProcessedData {
     uint32 num_samps = 17;
     uint32 max_num_beams = 18;
     repeated DebugData debug_data = 19;  // 1 for each filter output stage (including antennas_iq)
+    uint32 rawrf_num_samps = 20;
 
     message DebugData {
         string stagename = 1;

--- a/utils/protobuf/processeddata.proto
+++ b/utils/protobuf/processeddata.proto
@@ -20,14 +20,13 @@ message ProcessedData {
     string bfiq_main_shm = 15;
     string bfiq_intf_shm = 16;
     uint32 num_samps = 17;
-    uint32 num_antennas = 18;	// Could get this from options?
-    uint32 max_num_beams = 19;
-    repeated DebugData debug_data = 20;  // 1 for each filter output stage (including antennas_iq)
+    uint32 max_num_beams = 18;
+    repeated DebugData debug_data = 19;  // 1 for each filter output stage (including antennas_iq)
 
     message DebugData {
         string stagename = 1;
-        string main_shm_name = 2;
-        string intf_shm_name = 3;
+        string main_shm = 2;
+        string intf_shm = 3;
         uint32 num_samps = 4;
     }
 
@@ -40,6 +39,5 @@ message ProcessedData {
         uint32 num_lags = 6;
         uint32 slice_id = 7;
         repeated float noise_at_freq = 8; //TODO fill and parse
-        uint32 num_antennas = 9;
     }
 }

--- a/utils/protobuf/processeddata.proto
+++ b/utils/protobuf/processeddata.proto
@@ -17,7 +17,19 @@ message ProcessedData {
     uint32 lp_status_bank_h = 12;
     uint32 agc_status_bank_l = 13;
     uint32 lp_status_bank_l = 14;
-    repeated string shm_names = 15;
+    string bfiq_main_shm = 15;
+    string bfiq_intf_shm = 16;
+    uint32 num_samps = 17;
+    uint32 num_antennas = 18;	// Could get this from options?
+    uint32 max_num_beams = 19;
+    repeated DebugData debug_data = 20;  // 1 for each filter output stage (including antennas_iq)
+
+    message DebugData {
+        string stagename = 1;
+        string main_shm_name = 2;
+        string intf_shm_name = 3;
+        uint32 num_samps = 4;
+    }
 
     message OutputDataSet {
         string mainacf = 1;
@@ -26,23 +38,8 @@ message ProcessedData {
         uint32 num_beams = 4;
         uint32 num_ranges = 5;
         uint32 num_lags = 6;
-        repeated BeamData beamformedsamples = 7;
-        repeated DebugData debugsamples = 8;
-        uint32 slice_id = 9;
-        repeated float noise_at_freq = 10; //TODO fill and parse
-
-        message BeamData {
-            uint32 beamnum = 1;
-            string mainsamples = 2;
-            string intfsamples = 3;
-            uint32 num_samps = 4;
-        }
-
-        message DebugData {
-            string stagename = 1;
-            string antennadata = 2;
-            uint32 num_antennas = 3;
-            uint32 num_samps = 4;
-        }
+        uint32 slice_id = 7;
+        repeated float noise_at_freq = 8; //TODO fill and parse
+        uint32 num_antennas = 9;
     }
 }


### PR DESCRIPTION
* Transfer all data between rx_signal_processing.py and data_write.py using shared_memory. Only passes the names and data dimensions with the protobuf, and data_write opens shared memory and gets the data. 
* All data from the GPU is copied directly into shared memory on the CPU (if needed) to avoid unnecessary re-copying of data into shared memory.
* On labborealis, takes ~4ms to decimate, beamform, and correlate data; less than 1ms to fill the processeddata protobuf and send to data_write; and ~55ms to copy rawrf data to shared memory (but only if `__debug__` flag is set). If `__debug__` is set, filter data is also sent, which bumps up the time to write filter + antennas_iq data to protobuf up to 16ms. 
* All in all, the most significant speed up comes from only sending rawrf data to data_write if it is needed. This should sufficiently speed up the system to be comparable to C++ processing (which copies rawrf data to shared memory while asynchronously copying to GPU, to save time. This could be done in Python too, if there is a way to asynchronously copy data to cupy array.)