### PR TITLE
Sequence bound

### DIFF
--- a/experiment_prototype/experiment_prototype.py
+++ b/experiment_prototype/experiment_prototype.py
@@ -90,7 +90,7 @@ slice_key_set = frozenset(["slice_id", "cpid", "tx_antennas", "rx_main_antennas"
                            "pulse_phase_offset", "tau_spacing", "pulse_len", "num_ranges", "first_range", "intt",
                            "intn", "beam_angle", "beam_order", "scanbound", "txfreq", "rxfreq", "clrfrqrange",
                            "averaging_method", "acf", "xcf", "acfint", "wavetype", "seqoffset", "iwavetable",
-                           "qwavetable", "comment", "range_sep", "lag_table"])
+                           "qwavetable", "comment", "range_sep", "lag_table", "align_sequences"])
 
 """
 These are the keys that are set by the user when initializing a slice. Some
@@ -170,6 +170,9 @@ acf *defaults*
 acfint *defaults*
     flag for interferometer autocorrelation data. The default is True if acf is True, otherwise
     False.
+
+align_sequences *defaults*
+    flag for aligning the start of the first pulse in each sequence to tenths of a second. Default False.
 
 averaging_method *defaults*
     a string defining the type of averaging to be done. Current methods are 'mean' or 'median'.
@@ -1639,6 +1642,9 @@ class ExperimentPrototype(object):
         if 'comment' not in exp_slice:
             slice_with_defaults['comment'] = ''
 
+        if 'align_sequences' not in exp_slice:
+            slice_with_defaults['align_sequences'] = False
+
         return slice_with_defaults
 
     def setup_slice(self, exp_slice):
@@ -1650,7 +1656,7 @@ class ExperimentPrototype(object):
 
         The following are always able to be defaulted, so are optional:
         "tx_antennas", "rx_main_antennas", "rx_int_antennas", "pulse_phase_offset", "scanboundflag",
-        "scanbound", "acf", "xcf", "acfint", "wavetype", "seqoffset", "averaging_method"
+        "scanbound", "acf", "xcf", "acfint", "wavetype", "seqoffset", "averaging_method", "align_sequences"
 
         The following are always required for processing acf, xcf, and acfint which we will assume
         we are always doing:

--- a/experiment_prototype/scan_classes/sequences.py
+++ b/experiment_prototype/scan_classes/sequences.py
@@ -22,6 +22,7 @@ from operator import itemgetter
 import collections
 import sys
 import os
+from functools import reduce
 
 from sample_building.sample_building import get_samples, get_phase_shift
 from experiment_prototype.scan_classes.scan_class_base import ScanClassBase
@@ -400,9 +401,9 @@ class Sequence(ScanClassBase):
 
         self.blanks = self.find_blanks()
 
-        self.align_sequences = False
-        for _, slice_obj in self.slice_dict.items():
-            self.align_sequences = self.align_sequences or slice_obj['align_sequences']
+        self.align_sequences = reduce(lambda a, b: a or b, [s['align_sequences'] for s in self.slice_dict.values()])
+        if self.align_sequences:
+            sequence_print("Aligning sequences to 0.1 second boundaries.")
 
     def make_sequence(self, beam_iter, sequence_num):
         """

--- a/experiment_prototype/scan_classes/sequences.py
+++ b/experiment_prototype/scan_classes/sequences.py
@@ -400,6 +400,10 @@ class Sequence(ScanClassBase):
 
         self.blanks = self.find_blanks()
 
+        self.align_sequences = False
+        for _, slice_obj in self.slice_dict.items():
+            self.align_sequences = self.align_sequences or slice_obj['align_sequences']
+
     def make_sequence(self, beam_iter, sequence_num):
         """
         Create the samples needed for each pulse in the sequence. This function is optimized to

--- a/experiments/normalscan.py
+++ b/experiments/normalscan.py
@@ -56,5 +56,6 @@ class Normalscan(ExperimentPrototype):
             "acf": True,
             "xcf": True,  # cross-correlation processing
             "acfint": True,  # interferometer acfs
+            "align_sequences": True # align start of sequence to tenths of a second
         })
 

--- a/experiments/normalscan.py
+++ b/experiments/normalscan.py
@@ -56,6 +56,6 @@ class Normalscan(ExperimentPrototype):
             "acf": True,
             "xcf": True,  # cross-correlation processing
             "acfint": True,  # interferometer acfs
-            "align_sequences": True # align start of sequence to tenths of a second
+            #"align_sequences": True # align start of sequence to tenths of a second
         })
 

--- a/usrp_drivers/usrp_driver.cpp
+++ b/usrp_drivers/usrp_driver.cpp
@@ -276,19 +276,21 @@ void transmit(zmq::context_t &driver_c, USRP &usrp_d, const DriverOptions &drive
     // Earliest possible time to start sending samples
     auto sequence_start_time = time_now + delay;
 
-    // Get the digit of the next tenth of a second after min_start_time
-    double tenth_of_second = std::ceil(sequence_start_time.get_frac_secs() * 10);
-    double fractional_second = tenth_of_second / 10;
-    // this occurs if the current time is 0.9+ seconds, so the rounding takes it up to 1.0 seconds.
-    if (fractional_second >= 0.95) {
-      fractional_second = 0.0;
-    }
+    if (driver_packet.align_sequences == true) {
+      // Get the digit of the next tenth of a second after min_start_time
+      double tenth_of_second = std::ceil(sequence_start_time.get_frac_secs() * 10);
+      double fractional_second = tenth_of_second / 10;
+      // this occurs if the current time is 0.9+ seconds, so the rounding takes it up to 1.0 seconds.
+      if (fractional_second >= 0.95) {
+        fractional_second = 0.0;
+      }
 
-    // Start the sequence at the next tenth of a second.
-    if (fractional_second < 0.05) {
-      sequence_start_time = uhd::time_spec_t(sequence_start_time.get_full_secs()+1, fractional_second);
-    } else {
-      sequence_start_time = uhd::time_spec_t(sequence_start_time.get_full_secs(), fractional_second);
+      // Start the sequence at the next tenth of a second.
+      if (fractional_second < 0.05) {
+        sequence_start_time = uhd::time_spec_t(sequence_start_time.get_full_secs()+1, fractional_second);
+      } else {
+        sequence_start_time = uhd::time_spec_t(sequence_start_time.get_full_secs(), fractional_second);
+      }
     }
 
     auto seqn_sampling_time = num_recv_samples/rx_rate;

--- a/usrp_drivers/usrp_driver.cpp
+++ b/usrp_drivers/usrp_driver.cpp
@@ -278,15 +278,18 @@ void transmit(zmq::context_t &driver_c, USRP &usrp_d, const DriverOptions &drive
 
     if (driver_packet.align_sequences() == true) {
       // Get the digit of the next tenth of a second after min_start_time
-      double tenth_of_second = std::ceil(sequence_start_time.get_frac_secs() * 10);
+      double tenth_of_second = std::ceil(sequence_start_time.get_frac_secs() * 10);	// Result is integer in 1 through 10
       double fractional_second = tenth_of_second / 10;
       // this occurs if the current time is 0.9+ seconds, so the rounding takes it up to 1.0 seconds.
+      // 0.95 chosen as fractional second will always be 0.0, 0.1, ..., 1.0 so it falls in between 0.9 and 1.0
       if (fractional_second >= 0.95) {
         fractional_second = 0.0;
       }
 
       // Start the sequence at the next tenth of a second.
+      // 0.05 chosen as fractional second will always be 0.0, 0.1, etc so it falls in between.
       if (fractional_second < 0.05) {
+	// this occurs if the fractional second is 0.0 because the second has rolled over
         sequence_start_time = uhd::time_spec_t(sequence_start_time.get_full_secs()+1, fractional_second);
       } else {
         sequence_start_time = uhd::time_spec_t(sequence_start_time.get_full_secs(), fractional_second);

--- a/usrp_drivers/usrp_driver.cpp
+++ b/usrp_drivers/usrp_driver.cpp
@@ -273,7 +273,17 @@ void transmit(zmq::context_t &driver_c, USRP &usrp_d, const DriverOptions &drive
     // Getting usrp box time to find out when to send samples. box_time continuously being updated.
     auto delay = uhd::time_spec_t(SET_TIME_COMMAND_DELAY);
     auto time_now = borealis_clocks.box_time;
-    auto sequence_start_time = time_now + delay;
+    // Earliest possible time to start sending samples
+    auto min_start_time = time_now + delay;
+    // Get the digit of the next tenth of a second after min_start_time
+    auto tenth_of_second = std::ceil(min_start_time.get_frac_secs() * 10) / 10;
+
+    // Start the sequence at the next tenth of a second.
+    if (tenth_of_second < 0.1) {
+      auto sequence_start_time = uhd::time_spec_t(min_start_time.get_full_secs()+1, tenth_of_second);
+    } else {
+      auto sequence_start_time = uhd::time_spec_t(min_start_time.get_full_secs(), tenth_of_second);
+    }
 
     auto seqn_sampling_time = num_recv_samples/rx_rate;
     TIMEIT_IF_TRUE_OR_DEBUG(false, COLOR_BLUE("TRANSMIT") << " full usrp time stuff ",

--- a/usrp_drivers/usrp_driver.cpp
+++ b/usrp_drivers/usrp_driver.cpp
@@ -276,7 +276,7 @@ void transmit(zmq::context_t &driver_c, USRP &usrp_d, const DriverOptions &drive
     // Earliest possible time to start sending samples
     auto sequence_start_time = time_now + delay;
 
-    if (driver_packet.align_sequences == true) {
+    if (driver_packet.align_sequences() == true) {
       // Get the digit of the next tenth of a second after min_start_time
       double tenth_of_second = std::ceil(sequence_start_time.get_frac_secs() * 10);
       double fractional_second = tenth_of_second / 10;

--- a/utils/protobuf/driverpacket.proto
+++ b/utils/protobuf/driverpacket.proto
@@ -14,6 +14,7 @@ message DriverPacket {
   double timetosendsamples = 9;
   bool SOB = 10;
   bool EOB = 11;
+  bool align_sequences = 12;
 
   message SamplesBuffer {
     repeated float real = 1;


### PR DESCRIPTION
Changes to enable aligning the start of the first pulse in a sequence to exact tenths of a second.

* Specify `'align_sequences': True` in a slice when creating your experiment to enable this functionality.
* Tenths of a second should be fine for most use cases, as typical 7- and 8-pulse sequences collect data for ~90 ms, so there is very little wasted time. Could explore modifying this in the future for sequences with considerably different timing characteristics.
* Need to test with two separate systems to see if the sequences are indeed locked in time. 
* Should be merged after #327 

Timestamps from testing on labborealis machine show that the sequences are synchronized with 10ths of a second:

```
sqn_timestamps:
    1656702907.5999999046
    1656702907.7000000477
    1656702907.7999999523
    1656702907.9000000954
    1656702908.0000000000
    1656702908.0999999046
    1656702908.2000000477
    1656702908.2999999523
    1656702908.4000000954
    1656702908.5000000000
    1656702908.5999999046
    1656702908.7000000477
    1656702908.7999999523
    1656702908.9000000954
    1656702909.0000000000
    1656702909.0999999046
    1656702909.2000000477
    1656702909.2999999523
    1656702909.4000000954
    1656702909.5000000000
    1656702909.5999999046
    1656702909.7000000477
    1656702909.7999999523
    1656702909.9000000954
    1656702910.0000000000
    1656702910.0999999046
    1656702910.2000000477
    1656702910.2999999523
    1656702910.4000000954
    1656702910.5000000000
    1656702910.5999999046
    1656702910.7000000477
    1656702910.7999999523
    1656702910.9000000954
    1656702911.0000000000
    1656702911.0999999046
    1656702911.2000000477
```