### PR TITLE
Zero interferometer USRP driver bug

### DIFF
--- a/src/data_write.py
+++ b/src/data_write.py
@@ -240,7 +240,7 @@ class ParseData(object):
         main_shm.unlink()
 
         intf_available = False
-        if self.processed_data.bfiq_intf_shm != '':
+        if self.processed_data.bfiq_intf_shm:
             intf_available = True
             intf_shm = shared_memory.SharedMemory(name=self.processed_data.bfiq_intf_shm)
             temp_data = np.ndarray((num_slices, max_num_beams, num_samps),

--- a/src/usrp_drivers/utils/driveroptions.cpp
+++ b/src/usrp_drivers/utils/driveroptions.cpp
@@ -125,13 +125,24 @@ DriverOptions::DriverOptions() {
     }
 
     // Remove trailing comma from channel strings
-    ma_recv_str.pop_back();
-    ma_tx_str.pop_back();
-    ma_channel_str.pop_back();
-    ia_recv_str.pop_back();
-    ia_channel_str.pop_back();
+    if (!ma_recv_str.empty())
+        ma_recv_str.pop_back();
+    if (!ma_tx_str.empty())
+        ma_tx_str.pop_back();
+    if (!ma_channel_str.empty())
+        ma_channel_str.pop_back();
+    if (!ia_recv_str.empty())
+        ia_recv_str.pop_back();
+    if (!ia_channel_str.empty())
+        ia_channel_str.pop_back();
 
-    auto total_recv_chs_str = ma_recv_str + "," + ia_recv_str;
+    std::string total_recv_chs_str;
+    if (ma_recv_str.empty())
+        total_recv_chs_str = ia_recv_str;
+    else if (ia_recv_str.empty())
+        total_recv_chs_str = ma_recv_str;
+    else
+        total_recv_chs_str = ma_recv_str + "," + ia_recv_str;
 
     clk_addr_ = config_pt.get<std::string>("gps_octoclock_addr");
 
@@ -188,6 +199,9 @@ DriverOptions::DriverOptions() {
         while (ss.good()) {
             std::string s;
             std::getline(ss, s, ',');
+            if (s.empty()) {
+                break;
+            }
             channels.push_back(boost::lexical_cast<size_t>(s));
         }
 


### PR DESCRIPTION
## Summary
Fixes bugs preventing USRP Driver and Data Write from running when zero interferometers are configured.

Resolves https://github.com/SuperDARNCanada/borealis/issues/351, https://github.com/SuperDARNCanada/borealis/issues/355

## Changes
- Added check for empty channel strings so `pop_back()` doesn't operate on empty string
- Added logic to ensure `total_recv_chs_str` has correct formatting (no commas at front or back)
- Added check for empty channel string so `make_channels_()` works correctly when no intf antennas configured