### PR TITLE
Changed logging for sending/receiving experiments

### DIFF
--- a/src/experiment_handler.py
+++ b/src/experiment_handler.py
@@ -248,8 +248,9 @@ def experiment_handler(semaphore, args):
 
         semaphore.acquire()
         if message in ['EXPNEEDED', 'NOERROR']:
-            log.info("sending new experiment from beginning", message=message)
-            # Starting anew
+            if message == 'EXPNEEDED':
+                log.info("sending new experiment", message=message)
+            # Starting anew if EXPNEEDED, otherwise sending None
             send_experiment(exp_handler_to_radar_control,
                             options.radctrl_to_exphan_identity,
                             serialized_exp)

--- a/src/radar_control.py
+++ b/src/radar_control.py
@@ -278,7 +278,7 @@ def search_for_experiment(radar_control_to_exp_handler, exphan_to_radctrl_iden, 
     if isinstance(new_exp, ExperimentPrototype):
         experiment = new_exp
         new_experiment_received = True
-        log.debug("new experiment found")
+        log.info("new experiment found")
     elif new_exp is not None:
         log.debug("received non experiment_prototype type")
     else:


### PR DESCRIPTION
VERY minor PR, per our confusion the other day. I looked into the code a bit more and clarified what was going on:

1. `radar_control` asks `experiment_handler` after every averaging period whether there is a new experiment to run
2. `experiment_handler` checks, and if so sends the new experiment; if not, sends `None`
3. `experiment_handler` was logging both cases as "sending a new experiment from beginning", which was misleading. Sometimes it was sending `None`
4. `radar_control` unpickles the message, and only updates the experiment if it is not `None` and inherits from `ExperimentPrototype`
5. No matter what radar_control received, it would log (at debug level) an appropriate message

The changes in this PR:
* In `experiment_handler`, only log if an actual experiment is sent. Logs at INFO level
* In `radar_control`, changed log level to INFO if actual experiment is received.