### PR TITLE
Docs build / scheduler config parsing bugfix

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,34 +36,32 @@ sys.path.insert(5, os.environ['PATH'])
 RADAR_ID = 'sas'
 os.environ['RADAR_ID'] = RADAR_ID
 
-# hack for readthedocs to cause it to run doxygen first: https://github.com/rtfd/readthedocs.org/issues/388
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if on_rtd:
-    # Doxygen: Reads all c++ source and header files, and parses the documentation to xml files 
-    # for further reading. 
-    run('doxygen')
 
-    # Breathe: parses xml files produced by doxygen and creates rst files for use by Sphinx Files
-    # are re-generated each call, no table of contents file is created, and only rst files are
-    # created. For more information, `breathe-apidoc --help`
-    cur_dir = os.path.abspath(os.path.dirname(__file__))
-    run(['breathe-apidoc', '--force', '--no-toc', '--generate', 'file', '-o', f'{cur_dir}/source', f'{cur_dir}/xml/'])
+# Doxygen: Reads all c++ source and header files, and parses the documentation to xml files 
+# for further reading. 
+run('doxygen')
 
-    # Update the experiment subrepo so experiment files can be read into documentation
-    run(['git', 'submodule', 'update', '--init'])
+# Breathe: parses xml files produced by doxygen and creates rst files for use by Sphinx Files
+# are re-generated each call, no table of contents file is created, and only rst files are
+# created. For more information, `breathe-apidoc --help`
+cur_dir = os.path.abspath(os.path.dirname(__file__))
+run(['breathe-apidoc', '--force', '--no-toc', '--generate', 'file', '-o', f'{cur_dir}/source', f'{cur_dir}/xml/'])
 
-    # Clone in the HDW repo temporarily so modules reading them don't throw errors
-    # TODO: Get this path into config file somehow, as that's now how we specify hdw location
-    run(['git', 'clone', 'https://github.com/SuperDARN/hdw', BOREALISPATH + '/hdw'])
+# Update the experiment subrepo so experiment files can be read into documentation
+run(['git', 'submodule', 'update', '--init'])
 
-    # Change config file HDW path to path accessible by ReadTheDocs
-    # TODO: Come up with a way that doesn't require modifying a version controlled config file
-    config_file = BOREALISPATH + f'/config/{RADAR_ID}/{RADAR_ID}_config.ini'
-    with open(config_file, 'r') as file:
-        data = json.load(file)
-    data['hdw_path'] = BOREALISPATH + '/hdw'
-    with open(config_file, 'w') as file:
-        json.dump(data, file)
+# Clone in the HDW repo temporarily so modules reading them don't throw errors
+# TODO: Get this path into config file somehow, as that's now how we specify hdw location
+run(['git', 'clone', 'https://github.com/SuperDARN/hdw', BOREALISPATH + '/hdw'])
+
+# Change config file HDW path to path accessible by ReadTheDocs
+# TODO: Come up with a way that doesn't require modifying a version controlled config file
+config_file = BOREALISPATH + f'/config/{RADAR_ID}/{RADAR_ID}_config.ini'
+with open(config_file, 'r') as file:
+    data = json.load(file)
+data['hdw_path'] = BOREALISPATH + '/hdw'
+with open(config_file, 'w') as file:
+    json.dump(data, file)
 
 
 # -- General configuration ------------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -14,3 +14,4 @@ latex
 inotify
 matplotlib
 sphinx-rtd-theme
+structlog

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -2,23 +2,7 @@
 Borealis Options
 ================
 
-
-.. automodule:: src.utils.options.data_write_options
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-.. automodule:: src.utils.options.experimentoptions
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-.. automodule:: src.utils.options.realtime_options
-    :members:
-    :undoc-members:
-    :show-inheritance:
-    
-.. automodule:: src.utils.options.signal_processing_options
+.. automodule:: src.utils.options
     :members:
     :undoc-members:
     :show-inheritance:

--- a/scheduler/remote_server_options.py
+++ b/scheduler/remote_server_options.py
@@ -8,9 +8,8 @@
     :copyright: 2019 SuperDARN Canada
 """
 
-from src.utils.general import load_config
-
-
+import os
+import json
 
 def ascii_encode_dict(data):
     return dict(map(lambda x: x.encode('ascii'), pair) for pair in data.items())
@@ -31,7 +30,20 @@ class RemoteServerOptions(object):
         super().__init__()
 
         # Gather the borealis configuration information
-        raw_config = load_config()
+        # Gather the borealis configuration information
+        if not os.environ["BOREALISPATH"]:
+            raise ValueError("BOREALISPATH env variable not set")
+        if not os.environ['RADAR_ID']:
+            raise ValueError('RADAR_ID env variable not set')
+        path = f'{os.environ["BOREALISPATH"]}/config/' \
+            f'{os.environ["RADAR_ID"]}/' \
+            f'{os.environ["RADAR_ID"]}_config.ini'
+        try:
+            with open(path, 'r') as data:
+                raw_config = json.load(data)
+        except IOError:
+            print(f'IOError on config file at {path}')
+            raise
 
         self._site_id = raw_config["site_id"]
 


### PR DESCRIPTION
- Fixed some small bugs that prevented ReadTheDocs from building cleanly
- Fixed config file parsing done within scheduler missed in recent PR
- Removed conditional within docs/conf.py that prevented certain code from running outside of ReadTheDocs

Docs successfully built on ReadTheDocs, viewable here: https://borealis.readthedocs.io/en/bugfix-missed_doc_update/