### PR TITLE
Adding alerts to restart_borealis

### DIFF
--- a/docs/source/starting_the_radar.rst
+++ b/docs/source/starting_the_radar.rst
@@ -74,7 +74,7 @@ integrating Slack alerts, see `here
 <https://www.howtogeek.com/devops/how-to-send-a-message-to-slack-from-a-bash-script/>`__. 
 
 To set up the daemon using ``systemd``, add a ``.service`` file within ``/usr/lib/systemd/system/``
-(for OpenSuSe). For example, ::
+(for openSUSE). For example, ::
 
     [Unit]
     Description=Restart borealis daemon

--- a/docs/source/starting_the_radar.rst
+++ b/docs/source/starting_the_radar.rst
@@ -55,20 +55,41 @@ This script should be added to the control computer boot-up scripts so that it g
 of scheduled commands.
 
 ------------------
-Automated restarts
+Automated Restarts
 ------------------
 
-Occasionally, the Borealis software stops due to some software or computer issue.
-In order to automatically restart the radar software when this occurs, and to avoid lengthy
-downtimes, a script called restart_borealis.py was written. This script is called via crontab
-periodically (every 10 minutes).
-The script checks for a config file, finds out where the data directory is from the configuration
-file, and then looks for the data file that is currently being written to.
-If the file was written to recently, it does nothing, if a certain threshold of time has
-passed since the file was written to, then it assumes that the radar has stopped running
-properly, and attempts to restart it.
+Occasionally, the Borealis software stops due to some software or computer issue. To automatically
+restart the radar software when this occurs, and to avoid lengthy downtimes, the scripts
+``restart_borealis.daemon`` and ``restart_borealis.py`` were created. 
 
-The crontab entry is shown below: ::
+``restart_borealis.py`` finds the directory Borealis writes to and checks the file most recently
+written to. If the file hasn't been written to within a specified time period, the script assumes
+the radar has stopped running and tries to restart it using ``stop_radar.sh`` and
+``start_radar.sh``.
+
+``restart_borealis.daemon`` runs continuously, periodically executing ``restart_borealis.py``. If
+the radar is restarted consecutive times, an alert is sent to our group's Slack workspace to notify
+us that the radar likely has a problem requiring manual intervention. For more information on
+integrating Slack alerts, see `here
+<https://www.howtogeek.com/devops/how-to-send-a-message-to-slack-from-a-bash-script/>`__. 
+
+To set up the daemon using ``systemd``, add a ``.service`` file within ``/usr/lib/systemd/system/``
+(for OpenSuSe). For example, ::
+
+    [Unit]
+    Description=Restart borealis daemon
+
+    [Service]
+    User=radar
+    ExecStart=/home/radar/borealis/scripts/restart_borealis.daemon
+    Restart=always
+
+    [Install]
+    WantedBy=multi-user.target
+
+Then, ``enable`` and ``start`` the daemon using the ``systemctl`` commands.
+
+Alternatively, ``restart_borealis.py`` can be run via ``crontab``, as shown below: ::
 
     */10 * * * * . $HOME/.profile; /usr/bin/python3 /home/radar/borealis/scripts/restart_borealis.py >> /home/radar/borealis/restart_log.txt 2>&1
 

--- a/scripts/restart_borealis.daemon
+++ b/scripts/restart_borealis.daemon
@@ -23,41 +23,44 @@
 # 
 # [Install]
 # WantedBy=multi-user.target
+#
+# Reference: https://www.howtogeek.com/devops/how-to-send-a-message-to-slack-from-a-bash-script/
 
 ###################################################################################################
 
 source "${HOME}/.profile"   # Source BOREALISPATH, RADAR_ID, and SLACK_WEBHOOK
-source "${BOREALISPATH}/borealis_env3.9/bin/activate"
+source "${BOREALISPATH}/borealis_env${PYTHON_VERSION}/bin/activate"
 
 readonly THRESHOLD=3     # Number of consecutive Borealis restarts before sending alert
-readonly INTERVAL=30     # Time in seconds between restart_borealis.py calls
+readonly INTERVAL=300    # Time in seconds between restart_borealis.py calls
 
 readonly LOGFILE="${HOME}/logs/restart_borealis.log"
 
 ###################################################################################################
 
-# exec &>> $LOGFILE  # Redirect all stdout/stderr in this script to LOGFILE
+exec &>> $LOGFILE  # Redirect all stdout/stderr in this script to LOGFILE
 
-printf "\nDaemon $0 starting on $(hostname) for ${RADAR_ID}\n"
-date --utc "+%Y%m%d %H:%M:%S UTC"
+TIMESTAMP=$(date --utc "+%Y%m%d %H:%M:%S UTC")
+printf "\n$TIMESTAMP Daemon $0 starting on $(hostname) for ${RADAR_ID}\n"
 
 restarts=0  # Number of consecutive restarts
 while true; do
-    python3 /home/radar/borealis/scripts/restart_borealis.py -r $INTERVAL
+    python3 /home/radar/borealis/scripts/restart_borealis.py --restart-after-seconds $INTERVAL
     retval=$?
     if [[ $retval -eq 0 ]]; then
         restarts=0
     else
         restarts=$((restarts + 1))
     fi
-    echo $restarts
 
-    if [[ $restarts -ge $THRESHOLD ]]; then  # Send alert to Slack
-        date --utc "+%Y%m%d %H:%M:%S UTC"
-        echo "Sending alert to Slack"
+    # [[ -eq ]] so only one alert is sent each time
+    if [[ $restarts -eq $THRESHOLD ]]; then  # Send alert to Slack
+        TIMESTAMP=$(date --utc "+%Y%m%d %H:%M:%S UTC")
+        printf "$TIMESTAMP Sending alert to Slack, restart #$restarts\n"
 
-        message="Alert: Borealis has been restarted $restarts consecutive times"
-        # curl --header "Content-type: application/json" --data "{'text':'${message}'}" $SLACK_WEBHOOK
+        message="restart_borealis: Borealis has been restarted consecutive times at $RADAR_ID"
+        curl --silent --header "Content-type: application/json" --data "{'text':'${message}'}" $SLACK_WEBHOOK
+        printf "\n"
     fi
 
     sleep $INTERVAL

--- a/scripts/restart_borealis.daemon
+++ b/scripts/restart_borealis.daemon
@@ -11,6 +11,8 @@
 #   - mutt (Installed with zypper)
 #   - postfix enabled and started
 #   - SLACK_WEBHOOK defined in ~/.profile to a valid Slack webhook URL
+#   - Any email or SMS-to-email addresses to be notified should be defined in the CONTACTS array
+#     within .profile
 #   - RADAR_ID, BOREALISPATH, and PYTHON_VERSION defined in ~/.profile
 #
 # This script should be ran as a systemd daemon. An example .service file is shown below:
@@ -60,7 +62,12 @@ while true; do
         printf "$TIMESTAMP Sending alert to Slack, restart #$restarts\n"
 
         message="restart_borealis: Borealis has been restarted consecutive times at $RADAR_ID"
+        # Send message to Slack
         curl --silent --header "Content-type: application/json" --data "{'text':'${message}'}" $SLACK_WEBHOOK
+        # Send message to all listed in $CONTACTS environment variable
+        for address in "${CONTACTS[@]}"; do
+            echo -e $message | mutt -- $address
+        done
         printf "\n"
     fi
 

--- a/scripts/restart_borealis.daemon
+++ b/scripts/restart_borealis.daemon
@@ -10,7 +10,7 @@
 # Dependencies:
 #   - mutt (Installed with zypper)
 #   - postfix enabled and started
-#   - SLACK_WEBHOOK defined in ~/.profile to a valid Slack webhook URL
+#   - SLACK_WEBHOOK, RADAR_ID, BOREALISPATH defined in ~/.profile to a valid Slack webhook URL
 #
 # This script should be ran as a systemd daemon. An example .service file is shown below:
 # [Unit]
@@ -26,7 +26,8 @@
 
 ###################################################################################################
 
-source "${HOME}/.profile"
+source "${HOME}/.profile"   # Source BOREALISPATH, RADAR_ID, and SLACK_WEBHOOK
+source "${BOREALISPATH}/borealis_env3.9/bin/activate"
 
 readonly THRESHOLD=3     # Number of consecutive Borealis restarts before sending alert
 readonly INTERVAL=30     # Time in seconds between restart_borealis.py calls
@@ -42,7 +43,7 @@ date --utc "+%Y%m%d %H:%M:%S UTC"
 
 restarts=0  # Number of consecutive restarts
 while true; do
-    python3 /home/radar/borealis/scripts/restart_borealis.py -r $INVERVAL
+    python3 /home/radar/borealis/scripts/restart_borealis.py -r $INTERVAL
     retval=$?
     if [[ $retval -eq 0 ]]; then
         restarts=0

--- a/scripts/restart_borealis.daemon
+++ b/scripts/restart_borealis.daemon
@@ -10,7 +10,8 @@
 # Dependencies:
 #   - mutt (Installed with zypper)
 #   - postfix enabled and started
-#   - SLACK_WEBHOOK, RADAR_ID, BOREALISPATH defined in ~/.profile to a valid Slack webhook URL
+#   - SLACK_WEBHOOK defined in ~/.profile to a valid Slack webhook URL
+#   - RADAR_ID, BOREALISPATH, and PYTHON_VERSION defined in ~/.profile
 #
 # This script should be ran as a systemd daemon. An example .service file is shown below:
 # [Unit]
@@ -28,7 +29,7 @@
 
 ###################################################################################################
 
-source "${HOME}/.profile"   # Source BOREALISPATH, RADAR_ID, and SLACK_WEBHOOK
+source "${HOME}/.profile"   # Source BOREALISPATH, RADAR_ID, PYTHON_VERSION, and SLACK_WEBHOOK
 source "${BOREALISPATH}/borealis_env${PYTHON_VERSION}/bin/activate"
 
 readonly THRESHOLD=3     # Number of consecutive Borealis restarts before sending alert

--- a/scripts/restart_borealis.daemon
+++ b/scripts/restart_borealis.daemon
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Copyright 2023 SuperDARN Canada, University of Saskatchewan
+# Author: Theodore Kolkman
+#
+# Script that runs continuously and periodically runs restart_borealis.py to check if Borealis is
+# running, and if not restart Borealis. This script keeps track of how often restart_borealis.py 
+# is called. If it is called repeatedly, an alert will be sent to the specified webhook (Slack in
+# our case) notifying us that something is likely wrong with Borealis.
+#
+# Dependencies:
+#   - mutt (Installed with zypper)
+#   - postfix enabled and started
+#   - SLACK_WEBHOOK defined in ~/.profile to a valid Slack webhook URL
+#
+# This script should be ran as a systemd daemon. An example .service file is shown below:
+# [Unit]
+# Description=Restart borealis daemon
+# 
+# [Service]
+# User=radar
+# ExecStart=/home/radar/borealis/scripts/restart_borealis.daemon
+# Restart=always
+# 
+# [Install]
+# WantedBy=multi-user.target
+
+###################################################################################################
+
+source "${HOME}/.profile"
+
+readonly THRESHOLD=3     # Number of consecutive Borealis restarts before sending alert
+readonly INTERVAL=30     # Time in seconds between restart_borealis.py calls
+
+readonly LOGFILE="${HOME}/logs/restart_borealis.log"
+
+###################################################################################################
+
+# exec &>> $LOGFILE  # Redirect all stdout/stderr in this script to LOGFILE
+
+printf "\nDaemon $0 starting on $(hostname) for ${RADAR_ID}\n"
+date --utc "+%Y%m%d %H:%M:%S UTC"
+
+restarts=0  # Number of consecutive restarts
+while true; do
+    python3 /home/radar/borealis/scripts/restart_borealis.py -r $INVERVAL
+    retval=$?
+    if [[ $retval -eq 0 ]]; then
+        restarts=0
+    else
+        restarts=$((restarts + 1))
+    fi
+    echo $restarts
+
+    if [[ $restarts -ge $THRESHOLD ]]; then  # Send alert to Slack
+        date --utc "+%Y%m%d %H:%M:%S UTC"
+        echo "Sending alert to Slack"
+
+        message="Alert: Borealis has been restarted $restarts consecutive times"
+        # curl --header "Content-type: application/json" --data "{'text':'${message}'}" $SLACK_WEBHOOK
+    fi
+
+    sleep $INTERVAL
+done

--- a/scripts/restart_borealis.py
+++ b/scripts/restart_borealis.py
@@ -18,6 +18,7 @@ from datetime import datetime as dt
 import glob
 import subprocess
 import time
+from textwrap import indent
 
 
 def get_args():
@@ -26,10 +27,10 @@ def get_args():
     """
     parser = argparse.ArgumentParser(description="Borealis Check")
     parser.add_argument('-r', '--restart-after-seconds', type=int, default=300,
-                        help='How many seconds can the data file be out of date before attempting '
-                             'to restart the radar? Default 300 seconds (5 minutes)')
-    parser.add_argument('-p', '--borealis-path', required=False, help='Path to Borealis directory',
-                        dest='borealis_path', default='/home/radar/borealis/')
+                        help="How many seconds can the data file be out of date before attempting "
+                             "to restart the radar? Default 300 seconds (5 minutes)")
+    parser.add_argument('-p', '--borealis-path', required=False, help="Path to Borealis directory",
+                        dest="borealis_path", default="/home/radar/borealis/")
     args = parser.parse_args()
     return args
 
@@ -43,8 +44,8 @@ def main():
     # Gather the borealis configuration information
     if not os.environ["BOREALISPATH"]:
         raise ValueError("BOREALISPATH env variable not set")
-    if not os.environ['RADAR_ID']:
-        raise ValueError('RADAR_ID env variable not set')
+    if not os.environ["RADAR_ID"]:
+        raise ValueError("RADAR_ID env variable not set")
     path = f'{os.environ["BOREALISPATH"]}/config/' \
            f'{os.environ["RADAR_ID"]}/' \
            f'{os.environ["RADAR_ID"]}_config.ini'
@@ -52,7 +53,7 @@ def main():
         with open(path, 'r') as data:
             raw_config = json.load(data)
     except IOError:
-        print(f'IOError on config file at {path}')
+        print(f"IOError on config file at {path}")
         raise
 
     data_directory = raw_config["data_directory"]
@@ -70,33 +71,44 @@ def main():
     now_utc_seconds = float(dt.utcnow().strftime("%s"))
 
     # How many seconds ago was the last write to a data file?
-    last_data_write = now_utc_seconds - new_file_write_time
-    print('Write: {}, Now: {}, Diff: {} s' 
-          ''.format(dt.utcfromtimestamp(new_file_write_time).strftime('%Y%m%d.%H%M:%S'), 
-                    dt.utcfromtimestamp(now_utc_seconds).strftime('%Y%m%d.%H%M:%S'),
-                    last_data_write))
+    last_data_write = int(now_utc_seconds - new_file_write_time)
+    print(f"Last write time: {dt.utcfromtimestamp(new_file_write_time).strftime('%Y-%m-%dT%H:%M:%S')}, "
+          f"Current time: {dt.utcfromtimestamp(now_utc_seconds).strftime('%Y-%m-%dT%H:%M:%S')}, "
+          f"Difference: {last_data_write} s")
 
     # if under the threshold it is OK, if not then there's a problem
-    print(f"{last_data_write} seconds since last write")
     if float(last_data_write) <= float(restart_after_seconds):
+        print(f"{last_data_write} s within {restart_after_seconds} s threshold "
+               "- no restart neccessary")
         sys.exit(0)
     else:
+        print(f"{last_data_write} s greater than {restart_after_seconds} s threshold "
+               "- attempting to restart Borealis")        
         # Now we attempt to restart Borealis
-        stop_borealis = subprocess.Popen(f"{borealis_path}/borealis/scripts/stop_radar.sh",
-                                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stop_borealis = subprocess.Popen(f"{borealis_path}/scripts/stop_radar.sh",
+                                         stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
         output, error = stop_borealis.communicate()
-        # Check out the output to make sure it's all good (empty output means it's all good)
+        print("Borealis stop_radar.sh called")
+        print(indent(output, "    "))
+        # Check that the stop_radar.sh script was successful (empty error output means it worked)
         if error:
-            print(f'Attempting to restart Borealis: {error}')
+            print("Error with stop_radar.sh:")
+            print(indent(error, "      "))
 
-        time.sleep(5)
+        time.sleep(1)
 
         # Now call the start radar script, reads will block, so no need to communicate with
         # this process.
-        start_borealis = subprocess.Popen(f"{borealis_path}/borealis/scripts/start_radar.sh",
-                                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        print('Borealis stop_radar.sh and start_radar.sh called')
-        sys.exit(0)
+        start_borealis = subprocess.Popen(f"{borealis_path}/scripts/start_radar.sh",
+                                          stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        output, error = start_borealis.communicate()
+        print("Borealis start_radar.sh called")
+        print(indent(output, "    "))
+        if error:
+            print("Error with start_radar:")
+            print(indent(error, "      "))
+
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/scripts/restart_borealis.py
+++ b/scripts/restart_borealis.py
@@ -78,7 +78,7 @@ def main():
     now_utc_seconds = float(dt.utcnow().strftime("%s"))
 
     # How many seconds ago was the last write to a data file?
-    last_data_write = int(now_utc_seconds - new_file_write_time)
+    last_data_write = now_utc_seconds - new_file_write_time
     print(f"Last write time: {dt.utcfromtimestamp(new_file_write_time).strftime('%Y-%m-%dT%H:%M:%S')}, "
           f"Current time: {dt.utcfromtimestamp(now_utc_seconds).strftime('%Y-%m-%dT%H:%M:%S')}, "
           f"Difference: {last_data_write} s")

--- a/scripts/restart_borealis.py
+++ b/scripts/restart_borealis.py
@@ -102,7 +102,7 @@ def main():
             print("Error with stop_radar.sh:")
             print(indent(error, "      "))
 
-        time.sleep(5)
+        time.sleep(1)
 
         # Now call the start radar script, reads will block, so no need to communicate with
         # this process.

--- a/scripts/start_radar.sh
+++ b/scripts/start_radar.sh
@@ -1,15 +1,23 @@
 #!/bin/bash
+source "${HOME}/.profile"
+source "${BOREALISPATH}/borealis_env${PYTHON_VERSION}/bin/activate"
+LOGFILE="/data/borealis_logs/start_stop.log"
 
+# Stop current remote_server.py process
 /usr/bin/pkill -9 -f remote_server.py
-source $HOME/.profile
 
-NOW=`date +'%Y%m%d %H:%M:%S'`
+# Start new remote_server.py process
+nohup python3 $BOREALISPATH/scheduler/remote_server.py \
+		--scd-dir=/home/radar/borealis_schedules \
+		--emails-filepath=/home/radar/borealis_schedules/emails.txt \
+		>> /home/radar/logs/scd.out 2>&1 &
 
-/usr/bin/nohup /usr/bin/python3 $BOREALISPATH/scheduler/remote_server.py --scd-dir=/home/radar/borealis_schedules --emails-filepath=/home/radar/borealis_schedules/emails.txt >/home/radar/logs/scd.out 2>&1 &
+pid=$!	# Get pid of remote_server.py process
+sleep 1
 
-retVal=$?
-if [[ $retVal -ne 0 ]]; then
-	echo "${NOW} START: Could not start radar." | tee -a /data/borealis_logs/start_stop.log
+NOW=$(date +'%Y%m%d %H:%M:%S')
+if ps -p $pid > /dev/null; then	 # Check if remote_server.py process still running
+	echo "${NOW} START: Radar processes started." | tee -a $LOGFILE
 else
-	echo "${NOW} START: Radar processes started." | tee -a /data/borealis_logs/start_stop.log
+	echo "${NOW} START: Could not start radar." | tee -a $LOGFILE
 fi

--- a/scripts/stop_radar.sh
+++ b/scripts/stop_radar.sh
@@ -1,19 +1,23 @@
 #!/bin/bash
+source "${HOME}/.profile"
+LOGFILE="/data/borealis_logs/start_stop.log"
 
+# Kill remote_server.py process
 /usr/bin/pkill -9 -f remote_server.py
-source /home/radar/.profile
-for i in `atq | awk '{print $1}'`
+
+# Remove all scheduled experiments from at queue
+for i in $(atq | awk '{print $1}')
 do 
 	atrm $i
 done  
 
-NOW=`date +'%Y%m%d %H:%M:%S'`
-
+# Kill Borealis
 screen -X -S borealis quit
-
 retVal=$?
+
+NOW=$(date +'%Y%m%d %H:%M:%S')
 if [[ $retVal -ne 0 ]]; then
-	echo "${NOW} STOP: Could not stop radar." | tee -a /data/borealis_logs/start_stop.log
+	echo "${NOW} STOP: Could not stop radar." | tee -a $LOGFILE
 else
-	echo "${NOW} STOP: Radar processes stopped." | tee -a /data/borealis_logs/start_stop.log
+	echo "${NOW} STOP: Radar processes stopped." | tee -a $LOGFILE
 fi


### PR DESCRIPTION
## Summary
This PR creates a daemon to control restart_borealis.py, allowing alerts to be sent when Borealis restarts repeatedly. Other changes are improved logging in restart/stop/start scripts and small bugfixes.

## Testing
Tested the daemon and scripts individually on the lab machine. Since the lab isn't setup to start Borealis via the scheduler, I simulated starting Borealis by manually running steamed_hams. 

**Next stage:** Testing at SAS - the daemon script can be manually copied over to the computers, and should work with the scripts on `main`, so we won't need to do a release first to test.
