### PR TITLE
Removed options and log_config dependency from ReadTheDocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,16 +57,18 @@ if on_rtd:  # Only run following changes on ReadTheDocs
     # TODO: Get this path into config file somehow, as that's now how we specify hdw location
     run(['git', 'clone', 'https://github.com/SuperDARN/hdw', f'{BOREALISPATH}/hdw'])
 
-    # Create data directory that RTD can see so no errors are thrown
+    # Create data and log directory that RTD can see so no errors are thrown
     run(['mkdir', '-p', f'{BOREALISPATH}/borealis_data'])
+    run(['mkdir', '-p', f'{BOREALISPATH}/borealis_logs'])
 
-    # Change config file hdw and data paths to paths accessible by ReadTheDocs
+    # Change config file hdw and data/log paths to paths accessible by ReadTheDocs
     # TODO: Come up with a way that doesn't require modifying a version controlled config file
     config_file = f'{BOREALISPATH}/config/{RADAR_ID}/{RADAR_ID}_config.ini'
     with open(config_file, 'r') as file:
         data = json.load(file)
     data['hdw_path'] = f'{BOREALISPATH}/hdw'
     data['data_directory'] = f'{BOREALISPATH}/borealis_data'
+    data['log_directory'] = f'{BOREALISPATH}/borealis_logs'
     with open(config_file, 'w') as file:
         json.dump(data, file)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ sys.path.insert(5, os.environ['PATH'])
 RADAR_ID = 'sas'
 os.environ['RADAR_ID'] = RADAR_ID
 
+# -- Pre-build configuration ----------------------------------------------
 
 # Doxygen: Reads all c++ source and header files, and parses the documentation to xml files 
 # for further reading. 
@@ -47,30 +48,8 @@ run('doxygen')
 cur_dir = os.path.abspath(os.path.dirname(__file__))
 run(['breathe-apidoc', '--force', '--no-toc', '--generate', 'file', '-o', f'{cur_dir}/source', f'{cur_dir}/xml/'])
 
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if on_rtd:  # Only run following changes on ReadTheDocs
-
-    # Update the experiment subrepo so experiment files can be read into documentation
-    run(['git', 'submodule', 'update', '--init'])
-
-    # Clone in the HDW repo temporarily so modules reading them don't throw errors
-    # TODO: Get this path into config file somehow, as that's now how we specify hdw location
-    run(['git', 'clone', 'https://github.com/SuperDARN/hdw', f'{BOREALISPATH}/hdw'])
-
-    # Create data and log directory that RTD can see so no errors are thrown
-    run(['mkdir', '-p', f'{BOREALISPATH}/borealis_data'])
-    run(['mkdir', '-p', f'{BOREALISPATH}/borealis_logs'])
-
-    # Change config file hdw and data/log paths to paths accessible by ReadTheDocs
-    # TODO: Come up with a way that doesn't require modifying a version controlled config file
-    config_file = f'{BOREALISPATH}/config/{RADAR_ID}/{RADAR_ID}_config.ini'
-    with open(config_file, 'r') as file:
-        data = json.load(file)
-    data['hdw_path'] = f'{BOREALISPATH}/hdw'
-    data['data_directory'] = f'{BOREALISPATH}/borealis_data'
-    data['log_directory'] = f'{BOREALISPATH}/borealis_logs'
-    with open(config_file, 'w') as file:
-        json.dump(data, file)
+# Update the experiment subrepo so experiment files can be read into documentation
+run(['git', 'submodule', 'update', '--init'])
 
 
 # -- General configuration ------------------------------------------------
@@ -96,7 +75,8 @@ extensions = [
     'myst_parser'
 ]
 
-autodoc_mock_imports = ["debug", "release"]
+# Modules that can't be imported on RTD will be ignored if they are listed here
+autodoc_mock_imports = ["debug", "release", "utils"]
 
 breathe_projects = {"borealis" : "xml/"}
 breathe_default_project = "borealis"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,21 +47,28 @@ run('doxygen')
 cur_dir = os.path.abspath(os.path.dirname(__file__))
 run(['breathe-apidoc', '--force', '--no-toc', '--generate', 'file', '-o', f'{cur_dir}/source', f'{cur_dir}/xml/'])
 
-# Update the experiment subrepo so experiment files can be read into documentation
-run(['git', 'submodule', 'update', '--init'])
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+if on_rtd:  # Only run following changes on ReadTheDocs
 
-# Clone in the HDW repo temporarily so modules reading them don't throw errors
-# TODO: Get this path into config file somehow, as that's now how we specify hdw location
-run(['git', 'clone', 'https://github.com/SuperDARN/hdw', BOREALISPATH + '/hdw'])
+    # Update the experiment subrepo so experiment files can be read into documentation
+    run(['git', 'submodule', 'update', '--init'])
 
-# Change config file HDW path to path accessible by ReadTheDocs
-# TODO: Come up with a way that doesn't require modifying a version controlled config file
-config_file = BOREALISPATH + f'/config/{RADAR_ID}/{RADAR_ID}_config.ini'
-with open(config_file, 'r') as file:
-    data = json.load(file)
-data['hdw_path'] = BOREALISPATH + '/hdw'
-with open(config_file, 'w') as file:
-    json.dump(data, file)
+    # Clone in the HDW repo temporarily so modules reading them don't throw errors
+    # TODO: Get this path into config file somehow, as that's now how we specify hdw location
+    run(['git', 'clone', 'https://github.com/SuperDARN/hdw', f'{BOREALISPATH}/hdw'])
+
+    # Create data directory that RTD can see so no errors are thrown
+    run(['mkdir', '-p', f'{BOREALISPATH}/borealis_data'])
+
+    # Change config file hdw and data paths to paths accessible by ReadTheDocs
+    # TODO: Come up with a way that doesn't require modifying a version controlled config file
+    config_file = f'{BOREALISPATH}/config/{RADAR_ID}/{RADAR_ID}_config.ini'
+    with open(config_file, 'r') as file:
+        data = json.load(file)
+    data['hdw_path'] = f'{BOREALISPATH}/hdw'
+    data['data_directory'] = f'{BOREALISPATH}/borealis_data'
+    with open(config_file, 'w') as file:
+        json.dump(data, file)
 
 
 # -- General configuration ------------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,3 +15,5 @@ inotify
 matplotlib
 sphinx-rtd-theme
 structlog
+graypy
+rich

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,5 +15,3 @@ inotify
 matplotlib
 sphinx-rtd-theme
 structlog
-graypy
-rich


### PR DESCRIPTION
### Summary
Previously, when building the documentation on ReadTheDocs, the entire Borealis code structure was essentially imported within ReadTheDocs. This meant that configuration options such as hdw repo location and borealis data directories had to be created on ReadTheDocs.

To get around this, I added the `utils` package to the `autodoc_mock_imports` list within `conf.py`. This prevents the ReadTheDocs build from failing when exceptions are thrown within files in the `utils` package (such as `options` and `log_config`).