### PR TITLE
Scheduler sync alerts

### DIFF
--- a/docs/source/scheduling.rst
+++ b/docs/source/scheduling.rst
@@ -12,10 +12,12 @@ grab them if there is anything new. At the time of writing, these files are host
 `<https://github.com/SuperDARN/schedules>`_. This automated script will then parse the lines from
 the file and convert them to schedule file (SCD) commands.
 
-The schedule files need to be synced to the radar sites. The SCD files that the local
-script adds to should all be in this directory so that syncing is all automated. This syncing is
-currently done via a daemon process (``scheduler_sync.daemon``) that continually watches the local files
-for changes using inotify, then rsyncs the changed files to each site.
+The schedule files need to be synced to the radar sites. The SCD files that the local script adds to
+should all be in this directory so that syncing is all automated. This syncing is currently done via
+a daemon process (``scheduler_sync.daemon``) that continually watches the local files for changes
+using inotify, then rsyncs the changed files to each site. If a schedule fails to sync, an alert is
+sent to our group's Slack workspace to notify us. For more information on integrating Slack alerts,
+see `here <https://www.howtogeek.com/devops/how-to-send-a-message-to-slack-from-a-bash-script/>`__. 
 
 The remote script (``remote_server.py``) will check for changes to any synced files and then generate
 ``atq`` command arguments for Borealis experiments to run. This allows us to utilize scheduling

--- a/scheduler/scheduler_sync.daemon
+++ b/scheduler/scheduler_sync.daemon
@@ -115,7 +115,7 @@ do
                 if [[ $retval -ne 0 ]]; then
                     printf "$(date --utc "+%Y%m%d %H:%M:%S UTC") - Error in syncing schedule, trying again\n"
                     attempts=$((attempts + 1))
-                    if [[ $attempts -ge $MAX_ATTEMPTS ]]; then
+                    if [[ $attempts -eq $MAX_ATTEMPTS ]]; then
                         message="scheduler_sync@$RADAR_ID: Schedule failed to sync for $RADAR_ID"
                         curl --silent --header "Content-type: application/json" --data "{'text':'${message}'}" $SLACK_WEBHOOK
                         break

--- a/scheduler/scheduler_sync.daemon
+++ b/scheduler/scheduler_sync.daemon
@@ -31,6 +31,7 @@
 #   - Maxwell is configured via autossh to each site Borealis computer with ports that correspond 
 #   to the SITE_NUM association
 #   - ssh link between SuperDARN-CSSDP -> Maxwell (no password prompt for rsync)
+#   - SLACK_WEBHOOK_[RADAR_ID] defined within .profile on mrcopy for each respective site
 #
 # Parameter RADAR_ID: [sas, pgr, rkn, inv, cly]
 
@@ -63,6 +64,10 @@ readonly DEST="radar@localhost"
 readonly DEST_PORT="5${SITE_ID}522"
 readonly DEST_DIR="/home/radar/borealis_schedules"
 
+# Define Slack webhook to send alert
+readonly SLACK_WEBHOOK="SLACK_WEBHOOK_${RADAR_ID^^}"  # ^^ makes $RADAR_ID all caps
+readonly MAX_ATTEMPTS=3  # Number of attempts before sending alert
+
 ###################################################################################################
 
 exec &>> $LOGFILE # Redirect STDOUT and STDERR to $LOGFILE
@@ -92,6 +97,7 @@ do
             # Sync the .scd file to site via Maxwell
             printf "Sending ${SCD_FILE} to ${DEST}:${DEST_DIR}\n"
             retval=1
+            attempts=0
             while [[ $retval -ne 0 ]]; do
                 rsync -av --rsh="ssh $MAXWELL ssh -p $DEST_PORT" "${SCD_FILE}" "${DEST}:${DEST_DIR}"
 
@@ -103,9 +109,17 @@ do
                 # Verify md5sum of destination file is same as source
                 md5sum --check --status $HOME/tmp.md5
                 retval=$?
-                if [[ $retval -ne 0]]; then
+                rm $HOME/tmp.md5
+
+                if [[ $retval -ne 0 ]]; then
                     printf "$(date --utc "+%Y%m%d %H:%M:%S UTC") - Error in syncing schedule, trying again\n"
-                    sleep 60  # Try again in 60s
+                    attempts=$((attempts + 1))
+                    if [[ $attempts -ge $MAX_ATTEMPTS ]]; then
+                        message="scheduler_sync@$RADAR_ID: Schedule failed to sync for $RADAR_ID"
+                        curl --silent --header "Content-type: application/json" --data "{'text':'${message}'}" $SLACK_WEBHOOK
+                        break
+                    fi
+                    sleep 5  # Try again in 5 s
                 fi
             done
 

--- a/scheduler/scheduler_sync.daemon
+++ b/scheduler/scheduler_sync.daemon
@@ -65,7 +65,8 @@ readonly DEST_PORT="5${SITE_ID}522"
 readonly DEST_DIR="/home/radar/borealis_schedules"
 
 # Define Slack webhook to send alert
-readonly SLACK_WEBHOOK="SLACK_WEBHOOK_${RADAR_ID^^}"  # ^^ makes $RADAR_ID all caps
+readonly WEBHOOK_VARIABLE="SLACK_WEBHOOK_${RADAR_ID^^}"  # ^^ makes $RADAR_ID all caps
+readonly SLACK_WEBHOOK="${!WEBHOOK_VARIABLE}"  # Get URL from $SLACK_WEBHOOK_[RADAR_ID]
 readonly MAX_ATTEMPTS=3  # Number of attempts before sending alert
 
 ###################################################################################################


### PR DESCRIPTION
## Summary
Added Slack alerts to scheduler sync daemon. Alerts trigger when scheduler fails to sync after retrying 3+ consecutive times.

## Testing
Tested on my local machine to ensure logic was correct.

Currently testing for all sites.