### PR TITLE
Bugfix: Zero interferometer antennas

### DIFF
--- a/src/data_write.py
+++ b/src/data_write.py
@@ -853,11 +853,17 @@ class DataWrite(object):
 
             for slice_num in xcfs:
                 slice_data = aveperiod_data[slice_num]
-                slice_data.xcfs = find_expectation_value(xcfs[slice_num]['data'])
+                if data_parsing.xcfs_available:
+                    slice_data.xcfs = find_expectation_value(xcfs[slice_num]['data'])
+                else:
+                    slice_data.xcfs = np.array([], np.complex64)
 
             for slice_num in intf_acfs:
                 slice_data = aveperiod_data[slice_num]
-                slice_data.intf_acfs = find_expectation_value(intf_acfs[slice_num]['data'])
+                if data_parsing.intfacfs_available:
+                    slice_data.intf_acfs = find_expectation_value(intf_acfs[slice_num]['data'])
+                else:
+                    slice_data.intf_acfs = np.array([], np.complex64)
 
             for slice_num, slice_data in aveperiod_data.items():
                 slice_data.data_descriptors = ['num_beams', 'num_ranges', 'num_lags']

--- a/src/experiment_prototype/experiment_slice.py
+++ b/src/experiment_prototype/experiment_slice.py
@@ -289,13 +289,13 @@ class ExperimentSlice:
     rxonly: Optional[StrictBool] = False
     tx_antennas: Optional[conlist(conint(ge=0, lt=options.main_antenna_count, strict=True),
                                   max_items=options.main_antenna_count,
-                                  unique_items=True)] = Field(default_factory=list)
+                                  unique_items=True)] = None
     rx_main_antennas: Optional[conlist(conint(ge=0, lt=options.main_antenna_count, strict=True),
                                        max_items=options.main_antenna_count,
-                                       unique_items=True)] = Field(default_factory=list)
+                                       unique_items=True)] = None
     rx_int_antennas: Optional[conlist(conint(ge=0, lt=options.intf_antenna_count, strict=True),
                                       max_items=options.intf_antenna_count,
-                                      unique_items=True)] = Field(default_factory=list)
+                                      unique_items=True)] = None
     tx_antenna_pattern: Optional[Callable] = default_callable
     tx_beam_order: Optional[beam_order_type] = Field(default_factory=list)
     intt: Optional[confloat(ge=0)] = None
@@ -399,13 +399,13 @@ class ExperimentSlice:
 
     @validator('tx_antennas')
     def check_tx_antennas(cls, tx_antennas):
-        if not tx_antennas:
+        if tx_antennas is None:
             tx_antennas = [i for i in options.main_antennas]
         return tx_antennas
 
     @validator('rx_main_antennas')
     def check_rx_main_antennas(cls, rx_main_antennas):
-        if not rx_main_antennas:
+        if rx_main_antennas is None:
             rx_main_antennas = [i for i in options.main_antennas]
         if len(rx_main_antennas) == 0:
             raise ValueError("Must have at least one main antenna for RX")
@@ -413,7 +413,7 @@ class ExperimentSlice:
 
     @validator('rx_int_antennas')
     def check_rx_int_antennas(cls, rx_int_antennas):
-        if not rx_int_antennas:
+        if rx_int_antennas is None:
             return [i for i in options.intf_antennas]
         return rx_int_antennas
 
@@ -479,7 +479,7 @@ class ExperimentSlice:
             for bmnum in tx_beam_order:
                 if bmnum >= num_beams:
                     raise ValueError(f"Slice {values['slice_id']} scan tx beam number {bmnum} DNE")
-        if len(values['tx_antennas']) == 0:
+        if 'tx_antennas' in values and len(values['tx_antennas']) == 0:
             raise ValueError("Must have TX antennas specified if tx_beam_order specified")
 
         return tx_beam_order
@@ -595,7 +595,7 @@ class ExperimentSlice:
             xcf = False
             log.info(f"XCF defaulted to False as ACF not set. Slice: {values['slice_id']}")
             return False
-        if xcf and len(values['rx_int_antennas']) == 0:
+        if xcf and 'rx_int_antennas' in values and len(values['rx_int_antennas']) == 0:
             raise ValueError("XCF set to True but no interferometer antennas present")
 
     @validator('acfint', always=True)
@@ -603,7 +603,7 @@ class ExperimentSlice:
         if 'acf' not in values or not values['acf']:
             acfint = False
             log.info(f"ACFINT defaulted to False as ACF not set. Slice: {values['slice_id']}")
-        if acfint and len(values['rx_int_antennas']) == 0:
+        if acfint and 'rx_int_antennas' in values and len(values['rx_int_antennas']) == 0:
             raise ValueError("ACFINT set to True but no interferometer antennas present")
         return acfint
 

--- a/src/experiment_prototype/scan_classes/sequences.py
+++ b/src/experiment_prototype/scan_classes/sequences.py
@@ -168,7 +168,7 @@ class Sequence(ScanClassBase):
                 self.basic_slice_pulses[slice_id] = phased_samps_for_beams
             else:
                 self.basic_slice_pulses[slice_id] = []
-                tx_main_phase_shift = np.zeros((rx_main_phase_shift.shape[0], len(exp_slice['tx_antennas'])),
+                tx_main_phase_shift = np.zeros((rx_main_phase_shift.shape[0], len(exp_slice.tx_antennas)),
                                                dtype=np.complex64)
             self.tx_main_phase_shifts[slice_id] = tx_main_phase_shift
 

--- a/src/radar_control.py
+++ b/src/radar_control.py
@@ -192,7 +192,7 @@ def send_dsp_metadata(radctrl_to_dsp, dsp_radctrl_iden, radctrl_to_brian, brian_
         chan_add.first_range = slice_dict[slice_id].first_range
         chan_add.range_sep = slice_dict[slice_id].range_sep
         chan_add.rx_int_antennas = slice_dict[slice_id].rx_int_antennas
-        log.info('rx intf antennas', slice_id=slice_id, antennas=slice_dict[slice_id].rx_int_antennas)
+
         main_bms = beam_dict[slice_id]['main']
         intf_bms = beam_dict[slice_id]['intf']
 

--- a/src/radar_control.py
+++ b/src/radar_control.py
@@ -191,7 +191,8 @@ def send_dsp_metadata(radctrl_to_dsp, dsp_radctrl_iden, radctrl_to_brian, brian_
         chan_add.num_ranges = slice_dict[slice_id].num_ranges
         chan_add.first_range = slice_dict[slice_id].first_range
         chan_add.range_sep = slice_dict[slice_id].range_sep
-
+        chan_add.rx_int_antennas = slice_dict[slice_id].rx_int_antennas
+        log.info('rx intf antennas', slice_id=slice_id, antennas=slice_dict[slice_id].rx_int_antennas)
         main_bms = beam_dict[slice_id]['main']
         intf_bms = beam_dict[slice_id]['intf']
 

--- a/src/utils/message_formats.py
+++ b/src/utils/message_formats.py
@@ -98,6 +98,7 @@ class RxChannel:
     num_ranges: int = None
     first_range: int = None
     range_sep: float = None
+    rx_int_antennas: list[int] = field(default_factory=list)
     beam_phases: np.ndarray = None
     lags: list[Lag] = field(default_factory=list)
 


### PR DESCRIPTION
## Problems that have been fixed
1. Setting `rx_int` to false for all n200s in the config file was causing rx_signal_processing.py to crash. This was because `intf_antenna_count` in the config file was being checked in order to determine whether intf antennas were present.
2. data_write.py would crash if there were no `rx_int_antennas` specified (config file like in 1.), even if `xcfs` and `intf_acfs` were not called for. 
3. If user specified an empty list for `tx_antennas`, `rx_main_antennas`, or `rx_int_antennas`, it would default to the full antenna list from the config file.
4. A slice could specify `rx_int_antennas` be empty, while also specifying `xcfs` and `intf_acfs` be True.
5. Bug in sequences.py preventing listening modes from working. 
6. Could specify `tx_antennas` as an empty list while also setting `tx_beam_order` - in essence, trying to transmit while not providing any transmit antennas.