### PR TITLE
HAM frequency restrictions

### DIFF
--- a/config/cly/restrict.dat.cly
+++ b/config/cly/restrict.dat.cly
@@ -1,9 +1,10 @@
 # Restricted frequency table for Clyde River.
-# 
+# Restricted HAM exclusive frequencies 14.000 MHz to 14.350 MHz with a 0.205 MHz buffer.
 default=12200
 9995 10005
 10964 11064
 13360 13419
 13879 13979
+13795 14555
 14990 15010
 19990 20010

--- a/config/inv/restrict.dat.inv
+++ b/config/inv/restrict.dat.inv
@@ -7,11 +7,13 @@
 # 0.205 MHz buffer added to account for emission bandwidth (200 kHz in license)
 # ** NOTE ** Although these restricted frequencies are the same as Saskatoon's, they are indeed
 # from the Inuvik radio license. **
+# Restricted HAM exclusive frequencies 14.000 MHz to 14.350 MHz with a 0.205 MHz buffer.
 default=13700
 7806 8373
 9007 9687
 9790 10402
 13155 13617
+13795 14555
 14785 15215
 15529 16005
 19785 20215

--- a/config/pgr/restrict.dat.pgr
+++ b/config/pgr/restrict.dat.pgr
@@ -2,8 +2,10 @@
 # License no. 010756308-007 effective March 15 2021
 # The use of frequencies in the following bands is not authorized: 9.995 - 10.005 MHz, 13.360 - 13.410 MHZ,
 # 14.990 - 15.010 MHZ, 19.990 - 20.010 MHZ
+# Restricted HAM exclusive frequencies 14.000 MHz to 14.350 MHz with a 0.205 MHz buffer.
 default=13700
 9790 10210
 13155 13615
+13795 14555
 14785 15215
 19785 20215

--- a/config/rkn/restrict.dat.rkn
+++ b/config/rkn/restrict.dat.rkn
@@ -1,4 +1,5 @@
 # Restricted frequency table for Rankin Inlet.
+# Restricted HAM exclusive frequencies 14.000 MHz to 14.350 MHz with a 0.205 MHz buffer.
 default=13500
 8005  8017
 8071  8082
@@ -9,6 +10,7 @@ default=13500
 9995  10005
 10191 10202
 13360 13419
+13795 14555
 14990 15010
 15729 15740
 15794 15805

--- a/config/sas/restrict.dat.sas
+++ b/config/sas/restrict.dat.sas
@@ -5,11 +5,13 @@
 # The use of the following frequencies is prohibited: 8.0115 MHz, 8.0765 MHz, 8.117 MHz, 8.1674 MHz, 9.2124 MHz,
 # 9.4815 MHz, 10.1965 MHz, 13.4115 MHz, 15.7345 MHz, 15.7995 MHz
 # 0.205 MHz buffer added to account for emission bandwidth (200 kHz in license)
+# Restricted HAM exclusive frequencies 14.000 MHz to 14.350 MHz with a 0.205 MHz buffer.
 default=13700
 7806 8373
 9007 9687
 9790 10402
 13155 13617
+13795 14555
 14785 15215
 15529 16005
 19785 20215


### PR DESCRIPTION
We received an email warning us that 14.00 MHz to 14.350 MHz is a HAM band and that we should add it to our restriction table. I have it for each site with a 0.205 MHz buffer (which may be excessive).

In Canada, the band is allocated exclusively for Amateur radio. The 14.250 MHz to 14.350 MHz is fixed service, which we may not interfere at some sites as we are also fixed. It all depends on pointing directions and power. The amateur are allowed 100 W ERP whereas we are allowed 1.567 kW ERP, so we would swamp them. Internationally, in some countries 14.250 MHz to 14.350 MHz is also a fixed service with a 24 dBW ERP.

Here are some helpful links:
https://www.rac.ca/rac-0-30-mhz-band-plan/
https://ised-isde.canada.ca/site/spectrum-management-telecommunications/en/learn-more/key-documents/consultations/canadian-table-frequency-allocations-sf10759#s2.1
http://www.classic.grss-ieee.org/frequency_allocations.html
