### PR TITLE
Restrict HAM band 14.0-14.35 MHz at all sites (plus buffer).

### DIFF
--- a/restrict.dat.cly
+++ b/restrict.dat.cly
@@ -1,9 +1,10 @@
 # Restricted frequency table for Clyde River.
-# 
+# Restricted HAM exclusive frequencies 14.000 MHz to 14.350 MHz with a 0.205 MHz buffer.
 default=12200
 9995 10005
 10964 11064
 13360 13419
 13879 13979
+13795 14555
 14990 15010
 19990 20010

--- a/restrict.dat.inv
+++ b/restrict.dat.inv
@@ -7,11 +7,13 @@
 # 0.205 MHz buffer added to account for emission bandwidth (200 kHz in license)
 # ** NOTE ** Although these restricted frequencies are the same as Saskatoon's, they are indeed
 # from the Inuvik radio license. **
+# Restricted HAM exclusive frequencies 14.000 MHz to 14.350 MHz with a 0.205 MHz buffer.
 default=13700
 7806 8373
 9007 9687
 9790 10402
 13155 13617
+13795 14555
 14785 15215
 15529 16005
 19785 20215

--- a/restrict.dat.pgr
+++ b/restrict.dat.pgr
@@ -2,8 +2,10 @@
 # License no. 010756308-007 effective March 15 2021
 # The use of frequencies in the following bands is not authorized: 9.995 - 10.005 MHz, 13.360 - 13.410 MHZ,
 # 14.990 - 15.010 MHZ, 19.990 - 20.010 MHZ
+# Restricted HAM exclusive frequencies 14.000 MHz to 14.350 MHz with a 0.205 MHz buffer.
 default=13700
 9790 10210
 13155 13615
+13795 14555
 14785 15215
 19785 20215

--- a/restrict.dat.rkn
+++ b/restrict.dat.rkn
@@ -1,4 +1,5 @@
 # Restricted frequency table for Rankin Inlet.
+# Restricted HAM exclusive frequencies 14.000 MHz to 14.350 MHz with a 0.205 MHz buffer.
 default=13500
 8005  8017
 8071  8082
@@ -9,6 +10,7 @@ default=13500
 9995  10005
 10191 10202
 13360 13419
+13795 14555
 14990 15010
 15729 15740
 15794 15805

--- a/restrict.dat.sas
+++ b/restrict.dat.sas
@@ -5,11 +5,13 @@
 # The use of the following frequencies is prohibited: 8.0115 MHz, 8.0765 MHz, 8.117 MHz, 8.1674 MHz, 9.2124 MHz,
 # 9.4815 MHz, 10.1965 MHz, 13.4115 MHz, 15.7345 MHz, 15.7995 MHz
 # 0.205 MHz buffer added to account for emission bandwidth (200 kHz in license)
+# Restricted HAM exclusive frequencies 14.000 MHz to 14.350 MHz with a 0.205 MHz buffer.
 default=13700
 7806 8373
 9007 9687
 9790 10402
 13155 13617
+13795 14555
 14785 15215
 15529 16005
 19785 20215


### PR DESCRIPTION
See PR #407 for more details.