### PR TITLE
Scheduler crashing bugfix

### DIFF
--- a/scheduler/remote_server.py
+++ b/scheduler/remote_server.py
@@ -21,7 +21,6 @@ import subprocess as sp
 import pickle as pkl
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
-import datetime
 
 import scd_utils
 import email_utils
@@ -111,7 +110,7 @@ def plot_timeline(timeline, scd_dir, time_of_interest, site_id):
         :returns:   Colormap instance 
         :rtype:     ColorMap
         """
-        return plt.cm.get_cmap(name, n)
+        return plt.colormaps[name]
 
     def split_event(long_event):
         """
@@ -602,6 +601,10 @@ def _main():
             subject = f"Successfully scheduled commands at {site_id}"
             emailer.email_log(subject, log_file, [plot_path, pickle_path])
 
+    start_time = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    print(f"\n{start_time} - Scheduler booted")
+    print(f"Inotify monitoring schedule file {scd_file}")
+
     # Make the schedule on restart of application
     make_schedule()
     new_notify = False
@@ -623,7 +626,7 @@ def _main():
                 event_types.extend(type_names)
 
             # File has been copied
-            print(event_types)
+            print(f"Events triggered: {event_types}]")
             if site_id in path:
                 if all(i in event_types for i in ["IN_OPEN", "IN_ACCESS", "IN_CLOSE_WRITE"]):
                     scd_utils.SCDUtils(path)

--- a/scheduler/remote_server.py
+++ b/scheduler/remote_server.py
@@ -549,8 +549,6 @@ def _main():
 
     scd_dir = args.scd_dir
 
-    emailer = email_utils.Emailer(args.emails_filepath)
-
     inot = inotify.adapters.Inotify()
 
     options = rso.RemoteServerOptions()
@@ -567,6 +565,8 @@ def _main():
         os.makedirs(log_dir)
 
     def make_schedule():
+        emailer = email_utils.Emailer(args.emails_filepath)
+
         time_of_interest = datetime.datetime.utcnow()
 
         log_time_str = time_of_interest.strftime("%Y.%m.%d.%H.%M")


### PR DESCRIPTION
This pull request fixes a small bug in remote_server.py

If the schedule file is updated consecutive times, remote_server.py will crash after updating the atq. This problem didn't come up very often, as Borealis often reboots in between schedule updates.

The problem was caused by the emailer - after sending an email after the initial schedule update, the program killed the `smtp` emailer instance. If the scheduler tried to send another email after this point, it would crash. This was fixed by re-creating an emailer instance before updating the schedule each time.
