### PR TITLE
Fix ReadTheDocs formatting

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@ version: 2
 build:
   os: "ubuntu-20.04"
   tools:
-    python: "3.9"
+    python: "3.11"
 
 sphinx:
   configuration: docs/conf.py
@@ -15,5 +15,5 @@ python:
   install:
   - requirements: docs/requirements.txt
 
-# formats:
-  # - pdf # Throws warnings when building on ReadTheDocs
+formats:
+  - pdf

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -14,6 +14,4 @@ sphinx:
 python:
   install:
   - requirements: docs/requirements.txt
-
-formats:
-  - pdf
+  

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -118,7 +118,7 @@ master_doc = 'index'
 # General information about the project.
 project = 'Borealis'
 copyright = '2018, SuperDARN Canada'
-author = 'SuperDARN Canada' #Keith Kotyk, Marci Detwiller, Kevin Krieger
+author = 'SuperDARN Canada'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -13,7 +13,7 @@ posix_ipc
 latex
 inotify
 matplotlib
-sphinx-rtd-theme==1.3.0
+sphinx-rtd-theme<0.5
 structlog
 h5py
 pydantic<=1.10.13

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -13,7 +13,7 @@ posix_ipc
 latex
 inotify
 matplotlib
-sphinx-rtd-theme
+sphinx-rtd-theme==1.3.0
 structlog
 h5py
 pydantic<=1.10.13

--- a/docs/source/setup_software.rst
+++ b/docs/source/setup_software.rst
@@ -271,22 +271,20 @@ see the note when running ``install_radar_deps.py``.
 
     /sbin/modprobe pps_ldisc && /usr/sbin/ldattach PPS /dev/[PPS tty] && /usr/local/bin/ntpd
 
+#. To verify that ntpd is working correctly, follow the steps outlined in the ntp `documentation
+<https://www.ntp.org/documentation/4.2.8-series/debug/>`. Check ``/var/log/messages`` for the output
+messages from ``ntpd``. Also see `PPS Clock Discipline
+<http://www.fifi.org/doc/ntp-doc/html/driver22.htm>` for information about the PPS ntp clock
+discipline.
+
 #. Verify that the realtime module is able to communicate with other modules. This can be done by
    running the following command in a new terminal while borealis is running. If all is well, the
    command should output that there is a device listening on the channel specified. ::
 
     ss --all | grep 9696
 
-#. For further reading on networking and tuning with the USRP devices, see
-   https://files.ettus.com/manual/page_transport.html and
-   https://kb.ettus.com/USRP_Host_Performance_Tuning_Tips_and_Tricks. Also see
-   http://www.fifi.org/doc/ntp-doc/html/driver22.htm for information about the PPS ntp clock
-   discipline, and the ``man`` pages for:
-
-    - ``tuned``
-    - ``cpupower``
-    - ``ethtool``
-    - ``ip``
-    - ``sysctl``
-    - ``modprobe``
-    - ``ldattach``
+#. For further reading on networking and tuning with the USRP devices, see `Transport Notes
+   <https://files.ettus.com/manual/page_transport.html>` and `USRP Host Performance Tuning Tips and
+   Tricks <https://kb.ettus.com/USRP_Host_Performance_Tuning_Tips_and_Tricks>`. Also check out the
+   man pages for ``tuned``, ``cpupower``, ``ethtool``, ``ip``, ``sysctl``, ``modprobe``, and
+   ``ldattach``

--- a/docs/source/setup_software.rst
+++ b/docs/source/setup_software.rst
@@ -271,11 +271,11 @@ see the note when running ``install_radar_deps.py``.
 
     /sbin/modprobe pps_ldisc && /usr/sbin/ldattach PPS /dev/[PPS tty] && /usr/local/bin/ntpd
 
-#. To verify that ntpd is working correctly, follow the steps outlined in the ntp `documentation
-<https://www.ntp.org/documentation/4.2.8-series/debug/>`. Check ``/var/log/messages`` for the output
-messages from ``ntpd``. Also see `PPS Clock Discipline
-<http://www.fifi.org/doc/ntp-doc/html/driver22.htm>` for information about the PPS ntp clock
-discipline.
+#. To verify that ntpd is working correctly, follow the steps outlined in the ntp 
+   `documentation <https://www.ntp.org/documentation/4.2.8-series/debug/>`. Check 
+   ``/var/log/messages`` for the output messages from ``ntpd``. Also see 
+   `PPS Clock Discipline <http://www.fifi.org/doc/ntp-doc/html/driver22.htm>` for information about 
+   the PPS ntp clock discipline.
 
 #. Verify that the realtime module is able to communicate with other modules. This can be done by
    running the following command in a new terminal while borealis is running. If all is well, the
@@ -283,8 +283,8 @@ discipline.
 
     ss --all | grep 9696
 
-#. For further reading on networking and tuning with the USRP devices, see `Transport Notes
-   <https://files.ettus.com/manual/page_transport.html>` and `USRP Host Performance Tuning Tips and
-   Tricks <https://kb.ettus.com/USRP_Host_Performance_Tuning_Tips_and_Tricks>`. Also check out the
-   man pages for ``tuned``, ``cpupower``, ``ethtool``, ``ip``, ``sysctl``, ``modprobe``, and
-   ``ldattach``
+#. For further reading on networking and tuning with the USRP devices, see 
+   `Transport Notes <https://files.ettus.com/manual/page_transport.html>` and 
+   `USRP Host Performance Tuning Tips and Tricks <https://kb.ettus.com/USRP_Host_Performance_Tuning_Tips_and_Tricks>`. 
+   Also check out the man pages for ``tuned``, ``cpupower``, ``ethtool``, ``ip``, ``sysctl``, 
+   ``modprobe``, and ``ldattach``

--- a/docs/source/setup_software.rst
+++ b/docs/source/setup_software.rst
@@ -272,9 +272,9 @@ see the note when running ``install_radar_deps.py``.
     /sbin/modprobe pps_ldisc && /usr/sbin/ldattach PPS /dev/[PPS tty] && /usr/local/bin/ntpd
 
 #. To verify that ntpd is working correctly, follow the steps outlined in the ntp 
-   `documentation <https://www.ntp.org/documentation/4.2.8-series/debug/>`. Check 
+   `documentation <https://www.ntp.org/documentation/4.2.8-series/debug/>`_. Check 
    ``/var/log/messages`` for the output messages from ``ntpd``. Also see 
-   `PPS Clock Discipline <http://www.fifi.org/doc/ntp-doc/html/driver22.htm>` for information about 
+   `PPS Clock Discipline <http://www.fifi.org/doc/ntp-doc/html/driver22.htm>`_ for information about 
    the PPS ntp clock discipline.
 
 #. Verify that the realtime module is able to communicate with other modules. This can be done by
@@ -284,7 +284,7 @@ see the note when running ``install_radar_deps.py``.
     ss --all | grep 9696
 
 #. For further reading on networking and tuning with the USRP devices, see 
-   `Transport Notes <https://files.ettus.com/manual/page_transport.html>` and 
-   `USRP Host Performance Tuning Tips and Tricks <https://kb.ettus.com/USRP_Host_Performance_Tuning_Tips_and_Tricks>`. 
+   `Transport Notes <https://files.ettus.com/manual/page_transport.html>`_ and 
+   `USRP Host Performance Tuning Tips and Tricks <https://kb.ettus.com/USRP_Host_Performance_Tuning_Tips_and_Tricks>`_. 
    Also check out the man pages for ``tuned``, ``cpupower``, ``ethtool``, ``ip``, ``sysctl``, 
    ``modprobe``, and ``ldattach``


### PR DESCRIPTION
ReadTheDocs for develop wasn't showing correct formatting - just raw html.

This problem was fixed by specifying an older version of `sphinx-rtd-theme` in `docs/requirements.txt`.

I also moved `.readthedocs.yaml` to the `docs/` directory, since we're allowed to do this now.