### PR TITLE
Scheduler quality of life update

### DIFF
--- a/scheduler/email_utils.py
+++ b/scheduler/email_utils.py
@@ -82,6 +82,12 @@ class Emailer(object):
         em['To'] = ", ".join(self.emails)
 
         em.attach(email.mime.text.MIMEText(body))
+        
+        # Print the email contents to the console
+        print(f"From: {self.sender}")
+        print(f"To: {', '.join(self.emails)}")
+        print(f"Subject: {str(subject)}")
+        print(body)
 
         if attachments:
             for attachment in attachments:

--- a/scheduler/local_scd_server.py
+++ b/scheduler/local_scd_server.py
@@ -235,8 +235,8 @@ class SWG(object):
 def main():
     """ """
     parser = argparse.ArgumentParser(description="Automatically schedules new events from the SWG")
-    parser.add_argument('--emails-filepath', required=True, help='A list of emails to send logs to')
     parser.add_argument('--scd-dir', required=True, help='The scd working directory')
+    parser.add_argument('--emails-filepath', help='A list of emails to send logs to')
     parser.add_argument('--force', action="store_true", help='Force an update to the schedules '
                                                              'for the next month')
     parser.add_argument('--first-run', action="store_true", 
@@ -250,7 +250,12 @@ def main():
     scd_dir = args.scd_dir
     scd_logs = scd_dir + "/logs"
 
-    emailer = email_utils.Emailer(args.emails_filepath)
+    if args.emails_filepath is None:
+        emails_filepath = f"{scd_dir}/emails.txt"
+    else:
+        emails_filepath = args.emails_filepath
+
+    emailer = email_utils.Emailer(emails_filepath)
 
     if not os.path.exists(scd_dir):
         os.makedirs(scd_dir)
@@ -266,6 +271,13 @@ def main():
 
     current_time = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
     print(f"{current_time} - Starting local_scd_server.py...")
+
+    if args.first_run:
+        # Create the .scd files for each site if running for first time
+        for s in sites:
+            filename = f"{scd_dir}/{s}.scd"
+            with open(filename, 'a'):
+                pass
 
     while True:
         if swg.new_swg_file_available() or args.first_run or force_next_month:

--- a/scheduler/local_scd_server.py
+++ b/scheduler/local_scd_server.py
@@ -264,8 +264,14 @@ def main():
 
     force_next_month = args.force
 
+    current_time = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+    print(f"{current_time} - Starting local_scd_server.py...")
+
     while True:
         if swg.new_swg_file_available() or args.first_run or force_next_month:
+            current_time = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+            print(f"{current_time} - New swg file available")
+
             swg.pull_new_swg_file()
 
             site_experiments = [swg.parse_swg_to_scd(EXPERIMENTS[s], s, args.first_run)

--- a/scheduler/remote_server.py
+++ b/scheduler/remote_server.py
@@ -370,12 +370,17 @@ def get_relevant_lines(scd_util, time_of_interest):
 def _main():
     """ """
     parser = argparse.ArgumentParser(description="Automatically schedules new SCD file entries")
-    parser.add_argument('--emails-filepath', required=True, help='A list of emails to send logs to')
+    parser.add_argument('--emails-filepath', help='A list of emails to send logs to')
     parser.add_argument('--scd-dir', required=True, help='The scd working directory')
 
     args = parser.parse_args()
 
     scd_dir = args.scd_dir
+    
+    if args.emails_filepath is None:
+        emails_filepath = f"{scd_dir}/emails.txt"
+    else:
+        emails_filepath = args.emails_filepath
 
     inot = inotify.adapters.Inotify()
 
@@ -393,7 +398,7 @@ def _main():
         os.makedirs(log_dir)
 
     def make_schedule():
-        emailer = email_utils.Emailer(args.emails_filepath)
+        emailer = email_utils.Emailer(emails_filepath)
 
         time_of_interest = datetime.datetime.utcnow()
 

--- a/scheduler/remote_server.py
+++ b/scheduler/remote_server.py
@@ -398,6 +398,7 @@ def _main():
         os.makedirs(log_dir)
 
     def make_schedule():
+        print("Making schedule...")
         emailer = email_utils.Emailer(emails_filepath)
 
         time_of_interest = datetime.datetime.utcnow()
@@ -461,7 +462,6 @@ def _main():
             # File has been copied
             print(f"Events triggered: {event_types}]")
             if site_id in path:
-                print("Schedule updated - make_schedule() called.")
                 if all(i in event_types for i in ["IN_OPEN", "IN_ACCESS", "IN_CLOSE_WRITE"]):
                     scd_utils.SCDUtils(path)
                     make_schedule()

--- a/scheduler/remote_server.py
+++ b/scheduler/remote_server.py
@@ -3,9 +3,15 @@
 """
     remote_server.py
     ~~~~~~~~~~~~~~~~
-    Using inotify to determine if changes to the SCD file are made, this script will automatically
-    parse new changes and update the schedule via Linux's atq. Plots and logs are produced to verify
-    if any issues occur.
+    This process runs on the Borealis computer at each radar site. This process should be running in
+    the background whenever the radar is on, doing the following:
+      - On start up, it schedules Borealis based on the existing schedule (.scd) file for the
+        respective site. This is done using the Linux `at` service and the `atq` command. 
+      - Using inotify, remote_server.py then watches the .scd file for the respective site for any
+        changes. If the .scd file is modified, the scheduled Borealis runs are updated. 
+        
+    Logs are printed to stdout. Specific logs for each time the schedule is updated are also created
+    in borealis_schedules/logs/ and are emailed to verify if any issues occur.
 
     :copyright: 2019 SuperDARN Canada
 """
@@ -14,13 +20,8 @@ import inotify.adapters
 import os
 import datetime
 import argparse
-import collections
 import copy
-import random
 import subprocess as sp
-import pickle as pkl
-import matplotlib.pyplot as plt
-import matplotlib.dates as mdates
 
 import scd_utils
 import email_utils
@@ -59,178 +60,6 @@ def format_to_atq(dt, experiment, scheduling_mode, first_event_flag=False, kwarg
         cmd_str = start_cmd + " | at -t %Y%m%d%H%M"
     cmd_str = dt.strftime(cmd_str)
     return cmd_str
-
-
-def plot_timeline(timeline, scd_dir, time_of_interest, site_id):
-    """Plots the timeline to better visualize runtime.
-    
-    :param  timeline:           A list of entries ordered chronologically as scheduled
-    :type   timeline:           list
-    :param  scd_dir:            The scd directory path. (example: /home/radar/borealis_schedules)
-    :type   scd_dir:            str
-    :param  time_of_interest:   The datetime holding the time of scheduling.
-    :type   time_of_interest:   Datetime
-    :param  site_id:            Site identifier for logs.
-    :type   site_id:            str
-
-    :returns:   Tuple of paths to the saved plots.
-    :rtype:     tuple(str, str)
-    """
-    fig, ax = plt.subplots()
-
-    first_date, last_date = None, None
-
-    timeline_list = [{}] * len(timeline)
-
-    def timeline_to_dict(t_list):
-        """
-        Converts the timeline list to an ordered dict for scheduling and
-        colour mapping
-        Returns:
-            OrderedDict: an ordered dict containing the timeline
-        """
-        t_dict = collections.OrderedDict()
-        for line in t_list:
-            if not line['order'] in t_dict:
-                t_dict[line['order']] = []
-
-            t_dict[line['order']].append(line)
-        return t_dict
-
-    def get_cmap(n, name='hsv'):
-        """
-        Returns a function that maps each index in 0, 1, ..., n-1 to a distinct
-        RGB color; the keyword argument name must be a standard mpl colormap name.
-
-        :param  n:      index to a RGB colour
-        :type   n:      int 
-        :param  name:   standard mpl colormap name (Default value = 'hsv')
-        :type   name:   str
-
-        :returns:   Colormap instance 
-        :rtype:     ColorMap
-        """
-        return plt.colormaps[name]
-
-    def split_event(long_event):
-        """
-        Recursively splits a long event that runs during two or more days into two events
-        in order to handle plotting.
-
-        :param  event:  
-        :type   event:  dict
-        """
-        if long_event['start'].day == long_event['end'].day:
-            return [long_event]
-        else:
-            new_event = dict()
-            new_event['color'] = long_event['color']
-            new_event['label'] = long_event['label']
-
-            one_day = datetime.timedelta(days=1)
-            midnight = datetime.datetime.combine(long_event['start'] + one_day, datetime.datetime.min.time())
-
-            first_dur = midnight - long_event['start']
-            second_dur = long_event['end'] - midnight
-
-            # handle the new event first
-            new_event['start'] = midnight
-            new_event['duration'] = second_dur
-            new_event['end'] = long_event['end']
-
-            # now handle the old long_event
-            long_event['duration'] = first_dur
-            long_event['end'] = midnight
-
-            return [long_event] + split_event(new_event)
-
-    # make random colors
-    timeline_dict = timeline_to_dict(timeline)
-    cmap = get_cmap(len(timeline_dict.items()))
-    colors = [cmap(i) for i in range(len(timeline_dict.items()))]
-    random.shuffle(colors)
-
-    # put the colors in and create event records with only start and end times,
-    # durations, colors, and labels
-    for i, (_, events) in enumerate(timeline_dict.items()):
-        for event in events:
-            event['color'] = colors[i]
-
-    plot_last = None
-    for i, event in enumerate(timeline):
-        event_item = dict()
-
-        event_item['color'] = event['color']
-        event_item['label'] = event['experiment']
-
-        event_item['start'] = event['time']
-
-        if event['duration'] == '-':
-            td = scd_utils.get_next_month_from_date(event['time']) - event['time']
-        else:
-            td = datetime.timedelta(minutes=int(event['duration']))
-
-        event_item['end'] = event_item['start'] + td
-        event_item['duration'] = td
-
-        timeline_list[i] = event_item
-
-        if i == 0:
-            first_date = event['time'].date()
-        if i == len(timeline_list) - 1:
-            last_date = event['time'] + td
-            plot_last = (last_date + datetime.timedelta(hours=12)).date()
-
-    event_list = []
-    # loop through events again, splitting them where necessary
-    for event in timeline_list:
-        event_list += split_event(event)
-
-    for event in event_list:
-        day_offset = event['start'].date() - first_date
-        start = event['start'] - day_offset
-        ax.barh(event['start'].date(), event['duration'], 0.16, left=start, color=event['color'], align='edge')
-        ax.text(x=(start + (event['duration'] / 2)), y=event['start'].date(), s=event['label'], color='k', rotation=45,
-                ha='right', va='top', fontsize=8)
-
-    hours = mdates.HourLocator(byhour=[0, 6, 12, 18, 24])
-    days = mdates.DayLocator()
-    x_fmt = mdates.DateFormatter('%H:%M')
-    y_fmt = mdates.DateFormatter('%m-%d')
-
-    ax.xaxis.set_major_locator(hours)
-    ax.xaxis.set_major_formatter(x_fmt)
-    plt.xticks(rotation=45)
-    ax.set_xlabel('Time of Day', fontsize=12)
-
-    ax.yaxis.set_major_locator(days)
-    ax.yaxis.set_major_formatter(y_fmt)
-    ax.yaxis.set_minor_locator(hours)
-    ax.set_ylim(first_date, plot_last)
-    ax.set_ylabel('Date, MM-DD', rotation='vertical', fontsize=12)
-
-    ax.set_title(f"Schedule from {first_date} to {last_date.date()}")
-
-    pretty_date_str = time_of_interest.strftime("%Y-%m-%d")
-    pretty_time_str = time_of_interest.strftime("%H:%M")
-
-    ax.annotate(f"Generated on {pretty_date_str} at {pretty_time_str} UTC", xy=(1, 1),
-                xycoords='axes fraction', fontsize=12, ha='right', va='top')
-
-    plot_time_str = time_of_interest.strftime("%Y.%m.%d.%H.%M")
-    plot_dir = f"{scd_dir}/timeline_plots"
-
-    if not os.path.exists(plot_dir):
-        os.makedirs(plot_dir)
-
-    plot_file = f"{plot_dir}/{site_id}.{plot_time_str}.png"
-    fig.set_size_inches(14, 8)
-    fig.savefig(plot_file, dpi=80)
-
-    pkl_file = f"{plot_dir}/{site_id}.{plot_time_str}.pickle"
-    pkl.dump(fig, open(pkl_file, 'wb'))
-
-    return plot_file, pkl_file
 
 
 def convert_scd_to_timeline(scd_lines, time_of_interest):
@@ -587,7 +416,6 @@ def _main():
         else:
 
             timeline, warnings = convert_scd_to_timeline(relevant_lines, time_of_interest)
-            plot_path, pickle_path = plot_timeline(timeline, scd_dir, time_of_interest, site_id)
             new_atq_str = timeline_to_atq(timeline, scd_dir, time_of_interest, site_id)
 
             with open(log_file, 'wb') as f:
@@ -599,7 +427,7 @@ def _main():
                     f.write(f"\n{warning}".encode())
 
             subject = f"Successfully scheduled commands at {site_id}"
-            emailer.email_log(subject, log_file, [plot_path, pickle_path])
+            emailer.email_log(subject, log_file)
 
     start_time = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
     print(f"\n{start_time} - Scheduler booted")
@@ -628,6 +456,7 @@ def _main():
             # File has been copied
             print(f"Events triggered: {event_types}]")
             if site_id in path:
+                print("Schedule updated - make_schedule() called.")
                 if all(i in event_types for i in ["IN_OPEN", "IN_ACCESS", "IN_CLOSE_WRITE"]):
                     scd_utils.SCDUtils(path)
                     make_schedule()

--- a/scheduler/scheduler_sync.daemon
+++ b/scheduler/scheduler_sync.daemon
@@ -61,7 +61,7 @@ fi
 
 readonly DEST_PORT="${RADAR_PORTS[${RADAR_NAME^^}]}"
 
-readonly WATCH_DIR="/data/borealis_schedules"
+readonly WATCH_DIR="/home/radman/borealis_schedules"
 readonly SCD_FILE="${WATCH_DIR}/${RADAR_ID}.scd"
 
 # Define logging directory
@@ -105,7 +105,7 @@ do
             printf "%s - Schedule modified for %s\n" "$(date --utc "+%Y%m%d %H:%M:%S UTC")" "$RADAR_ID"
             sleep 1     # Wait 1 s to ensure all changes to scd file are finished
 
-            # Sync the .scd file to site via Maxwell
+            # Sync the .scd file to site via autossh tunnels
             printf "Sending %s to %s:%s via port %s\n" "${SCD_FILE}" "${SCHEDULER_DEST}" "${DEST_DIR}" "${DEST_PORT}"
             retval=1
             attempts=0

--- a/scheduler/scheduler_sync.daemon
+++ b/scheduler/scheduler_sync.daemon
@@ -30,11 +30,13 @@
 #   - ssh link between computer and remote radar computers (no password prompt for rsync)
 #
 # Requires:
-#   - file ${HOME}/.scheduler with read permissions
-#       - file must declare an array RADAR_PORTS like
+#   - file ${HOME}/.scheduler with read permissions defining the following variables:
+#       - file must declare an array RADAR_PORTS as follows:
 #           declare -A RADAR_PORTS=(["SAS_BORE"]=xxxxx ["SAS_MAIN"]=yyyyy)
 #         where xxxxx and yyyyy are ports for an ssh connection to the computer.
-#       - file must also define SCHEDULER_DEST as SCHEDULER=username@host
+#       - SCHEDULER_DEST (example: username@host)
+#       - LOCAL_SCHEDULE_DIR (example: /home/radman/borealis_schedules)
+#       - REMOTE_SCHEDULE_DIR (example: /home/radar/borealis_schedules)
 #   - SLACK_WEBHOOK_[RADAR_ID] defined in ${HOME}/.profile, where RADAR_ID is SAS, PGR, etc.
 #
 # Parameter RADAR_NAME: [sas, pgr, rkn, inv, cly]_[bore, main] e.g. sas_bore or inv_main
@@ -59,9 +61,19 @@ if [[ ! -v "RADAR_PORTS[${RADAR_NAME^^}]" ]]; then    # ^^ makes $RADAR_NAME all
   exit 1
 fi
 
-readonly DEST_PORT="${RADAR_PORTS[${RADAR_NAME^^}]}"
+# Check that required variables are defined within .scheduler
+if [[ -v "SCHEDULER_DEST" || -v "LOCAL_SCHEDULE_DIR" || -v "REMOTE_SCHEDULE_DIR" ]]; then
+    printf "Required variables are not all defined within .scheduler\n"
+    exit 1
+fi
 
-readonly WATCH_DIR="/home/radman/borealis_schedules"
+# Define destination
+readonly DEST_PORT="${RADAR_PORTS[${RADAR_NAME^^}]}"    # Defined within .scheduler
+readonly DEST_ADDRESS="${SCHEDULER_DEST}"               # Defined within .scheduler
+readonly DEST_DIR="${REMOTE_SCHEDULE_DIR}"              # Defined within .scheduler
+
+# Define the directory and file we are watching
+readonly WATCH_DIR="${LOCAL_SCHEDULE_DIR}"              # Defined within .scheduler
 readonly SCD_FILE="${WATCH_DIR}/${RADAR_ID}.scd"
 
 # Define logging directory
@@ -69,9 +81,6 @@ script_name=$(basename "$0" | cut --fields 1 --delimiter '.')
 readonly LOG_DIR="${HOME}/logs/scheduler"
 mkdir --parents "${LOG_DIR}"
 readonly LOGFILE="${LOG_DIR}/${script_name}_${RADAR_NAME}.log"
-
-# Define destination
-readonly DEST_DIR="/home/radar/borealis_schedules"
 
 # Define Slack webhook to send alert
 readonly SLACK_WEBHOOK="SLACK_WEBHOOK_${RADAR_ID^^}"
@@ -106,15 +115,15 @@ do
             sleep 1     # Wait 1 s to ensure all changes to scd file are finished
 
             # Sync the .scd file to site via autossh tunnels
-            printf "Sending %s to %s:%s via port %s\n" "${SCD_FILE}" "${SCHEDULER_DEST}" "${DEST_DIR}" "${DEST_PORT}"
+            printf "Sending %s to %s:%s via port %s\n" "${SCD_FILE}" "${DEST_ADDRESS}" "${DEST_DIR}" "${DEST_PORT}"
             retval=1
             attempts=0
             while [[ $retval -ne 0 ]]; do
-                rsync --archive --verbose --perms --rsh="ssh -p $DEST_PORT" "${SCD_FILE}" "${SCHEDULER_DEST}:${DEST_DIR}"
+                rsync --archive --verbose --perms --rsh="ssh -p $DEST_PORT" "${SCD_FILE}" "${DEST_ADDRESS}:${DEST_DIR}"
 
                 ### Check that the schedule successfully made it to site ###
                 # Get the md5sum of the remote schedule file
-                ssh -n -p "$DEST_PORT" "${SCHEDULER_DEST}" "md5sum --binary ${DEST_DIR}/${FILE}" > "$TMP_FILE"
+                ssh -n -p "$DEST_PORT" "${DEST_ADDRESS}" "md5sum --binary ${DEST_DIR}/${FILE}" > "$TMP_FILE"
                 # Modify temp file so checksum can be compared to source schedule file
                 sed -i "s~${DEST_DIR}/${FILE}~${WATCH_DIR}/${FILE}~g" "$TMP_FILE"
                 # Verify md5sum of destination file is same as source

--- a/scheduler/scheduler_sync.daemon
+++ b/scheduler/scheduler_sync.daemon
@@ -26,7 +26,7 @@
 #       systemctl [command] scheduler_sync@[RADAR_NAME]
 #
 # Dependencies:
-#   - inotifywait (installed by `zypper in inotify-tools``)
+#   - inotifywait (installed by `zypper in inotify-tools`)
 #   - ssh link between computer and remote radar computers (no password prompt for rsync)
 #
 # Requires:
@@ -62,7 +62,7 @@ if [[ ! -v "RADAR_PORTS[${RADAR_NAME^^}]" ]]; then    # ^^ makes $RADAR_NAME all
 fi
 
 # Check that required variables are defined within .scheduler
-if [[ -v "SCHEDULER_DEST" || -v "LOCAL_SCHEDULE_DIR" || -v "REMOTE_SCHEDULE_DIR" ]]; then
+if [[ ! -v "SCHEDULER_DEST" || ! -v "LOCAL_SCHEDULE_DIR" || ! -v "REMOTE_SCHEDULE_DIR" ]]; then
     printf "Required variables are not all defined within .scheduler\n"
     exit 1
 fi

--- a/scheduler/scheduler_sync.daemon
+++ b/scheduler/scheduler_sync.daemon
@@ -26,7 +26,7 @@
 #       systemctl [command] scheduler_sync@[RADAR_NAME]
 #
 # Dependencies:
-#   - inotifywait (installed by zypper in inotify-tools)
+#   - inotifywait (installed by `zypper in inotify-tools``)
 #   - ssh link between computer and remote radar computers (no password prompt for rsync)
 #
 # Requires:
@@ -77,6 +77,8 @@ readonly DEST_DIR="/home/radar/borealis_schedules"
 readonly SLACK_WEBHOOK="SLACK_WEBHOOK_${RADAR_ID^^}"
 readonly MAX_ATTEMPTS=3  # Number of attempts before sending alert
 
+readonly TMP_FILE="/tmp/sync_${RADAR_NAME}.md5"
+
 ###################################################################################################
 
 exec &>> "$LOGFILE" # Redirect STDOUT and STDERR to $LOGFILE
@@ -112,13 +114,13 @@ do
 
                 ### Check that the schedule successfully made it to site ###
                 # Get the md5sum of the remote schedule file
-                ssh -n -p "$DEST_PORT" "${SCHEDULER_DEST}" "md5sum --binary ${DEST_DIR}/${FILE}" > "${HOME}/tmp.md5"
-                # Modify tmp.md5 so checksum can be compared to source schedule file
-                sed -i "s~${DEST_DIR}/${FILE}~${WATCH_DIR}/${FILE}~g" "${HOME}/tmp.md5"
+                ssh -n -p "$DEST_PORT" "${SCHEDULER_DEST}" "md5sum --binary ${DEST_DIR}/${FILE}" > "$TMP_FILE"
+                # Modify temp file so checksum can be compared to source schedule file
+                sed -i "s~${DEST_DIR}/${FILE}~${WATCH_DIR}/${FILE}~g" "$TMP_FILE"
                 # Verify md5sum of destination file is same as source
-                md5sum --check --status "$HOME/tmp.md5"
+                md5sum --check --status "$TMP_FILE"
                 retval=$?
-                rm $HOME/tmp.md5
+                rm "$TMP_FILE"
                 
                 if [[ $retval -ne 0 ]]; then
                     printf "%s - Error in syncing schedule, trying again\n" "$(date --utc "+%Y%m%d %H:%M:%S UTC")"

--- a/scripts/restart_borealis.daemon
+++ b/scripts/restart_borealis.daemon
@@ -16,6 +16,7 @@
 #   - RADAR_ID, BOREALISPATH, and PYTHON_VERSION defined in ~/.profile
 #
 # This script should be ran as a systemd daemon. An example .service file is shown below:
+# /usr/lib/systemd/system/restart_borealis.service
 # [Unit]
 # Description=Restart borealis daemon
 # 

--- a/scripts/start_radar.sh
+++ b/scripts/start_radar.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source "$/home/radar/.profile"
+source "/home/radar/.profile"
 source "${BOREALISPATH}/borealis_env${PYTHON_VERSION}/bin/activate"
 LOGFILE="/home/radar/logs/start_stop.log"
 
@@ -20,7 +20,7 @@ if ! ps -p $pid > /dev/null; then	 # Check if remote_server.py process still run
 	exit 1
 fi
 
-if ! atq &>/dev/null; then		# Check if atq is empty
+if [[ -z $(atq) ]]; then		# Check if atq is empty
 	echo "${NOW} START: FAIL - atq is empty. No radar processes scheduled." | tee -a $LOGFILE
 	exit 1
 fi

--- a/scripts/start_radar.sh
+++ b/scripts/start_radar.sh
@@ -11,11 +11,11 @@ nohup python3 $BOREALISPATH/scheduler/remote_server.py \
 		--scd-dir=/home/radar/borealis_schedules \
 		>> /home/radar/logs/scd.out 2>&1 &
 
-pid=$!	# Get pid of remote_server.py process
+PID=$!	# Get pid of remote_server.py process
 sleep 1
 
 NOW=$(date +'%Y%m%d %H:%M:%S')
-if ! ps -p $pid > /dev/null; then	 # Check if remote_server.py process still running
+if ! ps -p $PID &> /dev/null; then	 # Check if remote_server.py process still running
 	echo "${NOW} START: FAIL - remote_server.py failed to start." | tee -a $LOGFILE
 	exit 1
 fi

--- a/scripts/stop_radar.sh
+++ b/scripts/stop_radar.sh
@@ -20,8 +20,9 @@ if screen -ls | grep -q borealis; then
 	retVal=$?
 fi
 
+sleep 1
 NOW=$(date +'%Y%m%d %H:%M:%S')
-if ps -p $PID > /dev/null; then	 # Check if remote_server.py process still running
+if ps -p $PID &> /dev/null; then	 # Check if remote_server.py process still running
 	echo "${NOW} STOP: FAIL - could not kill remote_server.py process." | tee -a $LOGFILE
 	exit 1
 fi

--- a/scripts/stop_radar.sh
+++ b/scripts/stop_radar.sh
@@ -1,23 +1,39 @@
 #!/bin/bash
-source "${HOME}/.profile"
-LOGFILE="/data/borealis_logs/start_stop.log"
+source "$/home/radar/.profile"
+LOGFILE="/home/radar/logs/start_stop.log"
 
 # Kill remote_server.py process
-/usr/bin/pkill -9 -f remote_server.py
+PID=$(pgrep -f remote_server.py) # Get PID of remote_server.py process
+kill -9 $PID
 
 # Remove all scheduled experiments from at queue
 for i in $(atq | awk '{print $1}')
 do 
 	atrm $i
-done  
+done
 
-# Kill Borealis
-screen -X -S borealis quit
-retVal=$?
+# Check if Borealis screen is still running
+retVal=0
+if screen -ls | grep -q borealis; then
+	# Kill Borealis processes
+	screen -X -S borealis quit
+	retVal=$?
+fi
 
 NOW=$(date +'%Y%m%d %H:%M:%S')
-if [[ $retVal -ne 0 ]]; then
-	echo "${NOW} STOP: Could not stop radar." | tee -a $LOGFILE
-else
-	echo "${NOW} STOP: Radar processes stopped." | tee -a $LOGFILE
+if ps -p $PID > /dev/null; then	 # Check if remote_server.py process still running
+	echo "${NOW} STOP: FAIL - could not kill remote_server.py process." | tee -a $LOGFILE
+	exit 1
 fi
+
+if atq &>/dev/null; then		# Check if atq isn't empty
+	echo "${NOW} STOP: FAIL - could not clear atq. Radar processes still scheduled." | tee -a $LOGFILE
+	exit 1
+fi
+
+if [[ $retVal -ne 0 ]]; then
+	echo "${NOW} STOP: FAIL - could not kill Borealis screen." | tee -a $LOGFILE
+	exit 1
+fi
+
+echo "${NOW} STOP: SUCCESS - radar processes stopped." | tee -a $LOGFILE

--- a/scripts/stop_radar.sh
+++ b/scripts/stop_radar.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-source "$/home/radar/.profile"
+source "/home/radar/.profile"
 LOGFILE="/home/radar/logs/start_stop.log"
 
 # Kill remote_server.py process
 PID=$(pgrep -f remote_server.py) # Get PID of remote_server.py process
-kill -9 $PID
+pkill -9 -f remote_server.py
 
 # Remove all scheduled experiments from at queue
 for i in $(atq | awk '{print $1}')
@@ -26,7 +26,7 @@ if ps -p $PID > /dev/null; then	 # Check if remote_server.py process still runni
 	exit 1
 fi
 
-if atq &>/dev/null; then		# Check if atq isn't empty
+if [[ -n $(atq) ]]; then		# Check if atq is not empty
 	echo "${NOW} STOP: FAIL - could not clear atq. Radar processes still scheduled." | tee -a $LOGFILE
 	exit 1
 fi


### PR DESCRIPTION
## Overview
This pull request makes the following changes:
- Fixes a small bug with schedule syncing
- Improves logging within local and remote server processes
- Improves start_ and stop_radar.sh

## The Changes
The scheduler sync daemon was having problems monitoring changes to site .scd files. The problem was due to the `borealis_schedules` directory being a NAS mounted directory, so inotify couldn't properly see file modifications. The `borealis_schedules` directory was moved to `/home/radman` instead, which appears to have fixed the problem.

I made a few other small quality of life improvements to local_scd_server.py as well.

For local_server.py:
- I removed the plotting (it wasn't useful and cluttered up the code quite a bit)
- Added printing of email messages to stdout

For start_radar.sh and stop_radar.sh I added improved checks and more descriptive messages for when the script fails to start/stop the radar.

## Testing
The scheduler sync changes have been tested on radman.

The script changes have been tested on the lab borealis computer.