### PR TITLE
Fixed bug in experiment_unittests

### DIFF
--- a/config/sas/sas_config.ini
+++ b/config/sas/sas_config.ini
@@ -160,7 +160,7 @@
     "max_filtering_stages" : "6",
     "max_filter_taps_per_stage" : "2048",
     "router_address" : "tcp://127.0.0.1:6969",
-    "realtime_address" : "tcp://eth0:9696",
+    "realtime_address" : "tcp://127.0.0.1:9696",
     "ringbuffer_name": "data_ringbuffer",
     "ringbuffer_size_bytes" : "200e6",
     "data_directory" : "/data/borealis_data",

--- a/tests/experiments/experiment_unittests.py
+++ b/tests/experiments/experiment_unittests.py
@@ -30,7 +30,6 @@ import os
 import sys
 import inspect
 import pkgutil
-from pathlib import Path
 from importlib import import_module
 import json
 
@@ -181,7 +180,7 @@ def build_unit_tests():
         raise OSError(f"Error: experiment path {experiment_path} is invalid")
 
     # Iterate through all modules in the borealis_experiments directory
-    for (_, name, _) in pkgutil.iter_modules([Path(experiment_path)]):
+    for (_, name, _) in pkgutil.iter_modules([experiment_path]):
         imported_module = import_module('.' + name, package=f'borealis_experiments.{experiment_package}')
         # Loop through all attributes of each found module
         for i in dir(imported_module):
@@ -246,7 +245,7 @@ def build_experiment_tests(experiments=None, kwargs=None):
                 raise ValueError(f"Bad kwarg: {element}")
 
     # Iterate through all modules in the borealis_experiments directory
-    for (_, name, _) in pkgutil.iter_modules([Path(experiment_path)]):
+    for (_, name, _) in pkgutil.iter_modules([experiment_path]):
         if experiments is None or name in experiments:
             imported_module = import_module('.' + name, package=experiment_package)
             # Loop through all attributes of each found module


### PR DESCRIPTION
There was a problem with `pkgutil.itermodules` where passing a Path() object worked for certain python versions, but not others. Passing a string works for all versions.

The error this bugfix fixes was:
```
Traceback (most recent call last):
  File "/usr/lib64/python3.10/pkgutil.py", line 417, in get_importer
    importer = sys.path_importer_cache[path_item]
KeyError: PosixPath('/home/radar/borealis/src/borealis_experiments')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/radar/borealis//tests/experiments/experiment_unittests.py", line 372, in <module>
    run_tests(sys.argv[1:])
  File "/home/radar/borealis//tests/experiments/experiment_unittests.py", line 332, in run_tests
    build_experiment_tests(experiments, args.kwargs)
  File "/home/radar/borealis//tests/experiments/experiment_unittests.py", line 249, in build_experiment_tests
    for (_, name, _) in pkgutil.iter_modules([Path(experiment_path)]):
  File "/usr/lib64/python3.10/pkgutil.py", line 129, in iter_modules
    for i in importers:
  File "/usr/lib64/python3.10/pkgutil.py", line 421, in get_importer
    importer = path_hook(path_item)
  File "<frozen importlib._bootstrap_external>", line 1632, in path_hook_for_FileFinder
  File "<frozen importlib._bootstrap_external>", line 1504, in __init__
  File "<frozen importlib._bootstrap_external>", line 182, in _path_isabs
AttributeError: 'PosixPath' object has no attribute 'startswith'
```

See https://github.com/python/cpython/issues/88227 for more info