### PR TITLE
Added capture of Borealis console output

### DIFF
--- a/scripts/steamed_hams.py
+++ b/scripts/steamed_hams.py
@@ -201,14 +201,15 @@ if mode == "debug":
     modules['usrp_driver'] = f"source mode {mode}; {c_debug_opts} usrp_driver"
 
 # Set up the screenrc file and populate it
+log_dir = "/data/borealis_logs/"    # Temporary fix to give us access to exactly what's printed to console from Borealis
 screenrc = BOREALISSCREENRC.format(
-    START_RT=modules['realtime'],
-    START_BRIAN=modules['brian'],
-    START_USRP_DRIVER=modules['usrp_driver'],
-    START_DSP=modules['rx_signal_processing'],
-    START_DATAWRITE=modules['data_write'],
-    START_EXPHAN=modules['experiment_handler'],
-    START_RADCTRL=modules['radar_control'],
+    START_RT=modules['realtime'] + " 2>&1 | tee " + log_dir + "realtime.log",
+    START_BRIAN=modules['brian'] + " 2>&1 | tee " + log_dir + "brian.log",
+    START_USRP_DRIVER=modules['usrp_driver'] + " 2>&1 | tee " + log_dir + "usrp_driver.log",
+    START_DSP=modules['rx_signal_processing'] + " 2>&1 | tee " + log_dir + "rx_signal_processing.log",
+    START_DATAWRITE=modules['data_write'] + " 2>&1 | tee " + log_dir + "data_write.log",
+    START_EXPHAN=modules['experiment_handler'] + " 2>&1 | tee " + log_dir + "experiment_handler.log",
+    START_RADCTRL=modules['radar_control'] + " 2>&1 | tee " + log_dir + "radar_control.log",
 )
 
 screenrc_file = os.environ['BOREALISPATH'] + "/borealisscreenrc"


### PR DESCRIPTION
To help with debugging, I've added a `tee` command for each Borealis process to capture the output printed to the Borealis screen. This will allow us to more easily view bugs in Borealis and view the output printed to the screen when Borealis crashes. 

The logs are printed to `/data/borealis_logs/[module].log`. These files will only contain the output most recently printed by Borealis, and will be overwritten each time `steamed_hams.py` runs.

This is a temporary fix, and should be improved upon in future logging improvements. Ideally, in the future this console output would be captures within our normal logs. As it currently stands though, any errors within Borealis that occur before StructLog initializes (i.e. import errors) aren't captured by our logs - thus why we need this PR. 