### PR TITLE
Bugfix/bad records

### DIFF
--- a/src/data_write.py
+++ b/src/data_write.py
@@ -224,6 +224,10 @@ class SliceData:
                 matching_fields.append(f.name)
         return matching_fields
 
+    def __repr__(self):
+        """Print all available fields"""
+        return f'{vars(self)}'
+
 
 @dataclass
 class ParseData(object):
@@ -585,7 +589,7 @@ class DataWrite(object):
                     elif isinstance(data, bool):
                         data = np.bool_(data)
                     elif isinstance(data, list):
-                        if isinstance(data[0], str):
+                        if len(data) > 0 and isinstance(data[0], str):
                             data = np.bytes_(data)
                         else:
                             data = np.array(data)

--- a/src/data_write.py
+++ b/src/data_write.py
@@ -589,6 +589,8 @@ class DataWrite(object):
                     elif isinstance(data, bool):
                         data = np.bool_(data)
                     elif isinstance(data, list):
+                        if len(data) == 0:
+                            log.warning('empty array', field=relevant_field, data=data)
                         if len(data) > 0 and isinstance(data[0], str):
                             data = np.bytes_(data)
                         else:


### PR DESCRIPTION
This PR aims to fix the intermittent issue in the `develop` branch where zero-sequence records throw an `IndexError` when being written to file. 

* Added a check to `write_hdf5_file()` in `data_write.py` that will circumvent the IndexError.
* Created custom `__repr__` method that won't fail due to missing attributes, and instead prints all attributes set.