### PR TITLE
Fixed bug in local_scd_server.py

### DIFF
--- a/scheduler/local_scd_server.py
+++ b/scheduler/local_scd_server.py
@@ -266,8 +266,6 @@ def main():
     else:
         emails_filepath = args.emails_filepath
 
-    emailer = email_utils.Emailer(emails_filepath)
-
     if not os.path.exists(scd_dir):
         os.makedirs(scd_dir)
 
@@ -302,6 +300,7 @@ def main():
 
             errors = False
             today = datetime.datetime.utcnow()
+            emailer = email_utils.Emailer(emails_filepath)
             scd_error_log = today.strftime("/scd_errors.%Y%m%d")
 
             for se, site_scd in zip(site_experiments, site_scds):


### PR DESCRIPTION
local_scd_server.py was crashing after updating the schedule for a second consecutive time while running from the same process. It is crashing because the emailer kills itself after sending an email the first time the while loop is entered, but a new emailer isn't created for subsequent loops.

To fix, I moved emailer class creation within while loop so a new one is made every loop.