### PR TITLE
Logging update

### DIFF
--- a/config/cly/cly_config.ini
+++ b/config/cly/cly_config.ini
@@ -180,14 +180,22 @@
     "ringbuffer_name": "data_ringbuffer",
     "ringbuffer_size_bytes" : "200e6",
     "data_directory" : "/data/borealis_data",
-    "log_directory" : "/data/borealis_logs",
-    "log_level" : "INFO",
     "log_handlers" : {
-                      "console" : true,
-                      "logfile" : true,
-                      "aggregator" : true
-                     },
-    "log_aggregator_addr" : "0.0.0.0",
-    "log_aggregator_port" : "12205",
+        "console" : {
+            "enable" : true,
+            "level" : "INFO"
+        },
+        "logfile" : {
+            "enable" : true,
+            "level" : "VERBOSE",
+            "directory" : "/data/borealis_logs"
+        },
+        "aggregator" : {
+            "enable" : true,
+            "level" : "VERBOSE",
+            "addr" : "0.0.0.0",
+            "port" : "12205"
+        }
+    },
     "hdw_path" : "/usr/local/hdw"
 }

--- a/config/inv/inv_config.ini
+++ b/config/inv/inv_config.ini
@@ -180,14 +180,22 @@
     "ringbuffer_name": "data_ringbuffer",
     "ringbuffer_size_bytes" : "200e6",
     "data_directory" : "/data/borealis_data",
-    "log_directory" : "/data/borealis_logs",
-    "log_level" : "INFO",
     "log_handlers" : {
-                      "console" : true,
-                      "logfile" : true,
-                      "aggregator" : true
-                     },
-    "log_aggregator_addr" : "0.0.0.0",
-    "log_aggregator_port" : "12204",
+        "console" : {
+            "enable" : true,
+            "level" : "INFO"
+        },
+        "logfile" : {
+            "enable" : true,
+            "level" : "VERBOSE",
+            "directory" : "/data/borealis_logs"
+        },
+        "aggregator" : {
+            "enable" : true,
+            "level" : "VERBOSE",
+            "addr" : "0.0.0.0",
+            "port" : "12204"
+        }
+    },
     "hdw_path" : "/usr/local/hdw"
 }

--- a/config/lab/lab_config.ini
+++ b/config/lab/lab_config.ini
@@ -180,14 +180,22 @@
     "ringbuffer_name": "data_ringbuffer",
     "ringbuffer_size_bytes" : "200e6",
     "data_directory" : "/data/borealis_data",
-    "log_directory" : "/data/borealis_logs",
-    "log_level" : "INFO",
     "log_handlers" : {
-                      "console" : true,
-                      "logfile" : true,
-                      "aggregator" : true
-                     },
-    "log_aggregator_addr" : "10.65.0.15",
-    "log_aggregator_port" : "12201",
+        "console" : {
+            "enable" : true,
+            "level" : "INFO"
+        },
+        "logfile" : {
+            "enable" : true,
+            "level" : "VERBOSE",
+            "directory" : "/data/borealis_logs"
+        },
+        "aggregator" : {
+            "enable" : true,
+            "level" : "VERBOSE",
+            "addr" : "10.65.0.15",
+            "port" : "12201"
+        }
+    },
     "hdw_path" : "/usr/local/hdw"
 }

--- a/config/pgr/pgr_config.ini
+++ b/config/pgr/pgr_config.ini
@@ -180,14 +180,22 @@
     "ringbuffer_name": "data_ringbuffer",
     "ringbuffer_size_bytes" : "200e6",
     "data_directory" : "/data/borealis_data",
-    "log_directory" : "/data/borealis_logs",
-    "log_level" : "INFO",
     "log_handlers" : {
-                      "console" : true,
-                      "logfile" : true,
-                      "aggregator" : true
-                     },
-    "log_aggregator_addr" : "0.0.0.0",
-    "log_aggregator_port" : "12202",
+        "console" : {
+            "enable" : true,
+            "level" : "INFO"
+        },
+        "logfile" : {
+            "enable" : true,
+            "level" : "VERBOSE",
+            "directory" : "/data/borealis_logs"
+        },
+        "aggregator" : {
+            "enable" : true,
+            "level" : "VERBOSE",
+            "addr" : "0.0.0.0",
+            "port" : "12202"
+        }
+    },
     "hdw_path" : "/usr/local/hdw"
 }

--- a/config/rkn/rkn_config.ini
+++ b/config/rkn/rkn_config.ini
@@ -180,14 +180,22 @@
     "ringbuffer_name": "data_ringbuffer",
     "ringbuffer_size_bytes" : "200e6",
     "data_directory" : "/data/borealis_data",
-    "log_directory" : "/data/borealis_logs",
-    "log_level" : "INFO",
     "log_handlers" : {
-                      "console" : true,
-                      "logfile" : true,
-                      "aggregator" : true
-                     },
-    "log_aggregator_addr" : "0.0.0.0",
-    "log_aggregator_port" : "12203",
+        "console" : {
+            "enable" : true,
+            "level" : "INFO"
+        },
+        "logfile" : {
+            "enable" : true,
+            "level" : "VERBOSE",
+            "directory" : "/data/borealis_logs"
+        },
+        "aggregator" : {
+            "enable" : true,
+            "level" : "VERBOSE",
+            "addr" : "0.0.0.0",
+            "port" : "12203"
+        }
+    },
     "hdw_path" : "/usr/local/hdw"
 }

--- a/config/sas/sas_config.ini
+++ b/config/sas/sas_config.ini
@@ -164,14 +164,22 @@
     "ringbuffer_name": "data_ringbuffer",
     "ringbuffer_size_bytes" : "200e6",
     "data_directory" : "/data/borealis_data",
-    "log_directory" : "/data/borealis_logs",
-    "log_level" : "INFO",
     "log_handlers" : {
-                      "console" : true,
-                      "logfile" : true,
-                      "aggregator" : true
-                     },
-    "log_aggregator_addr" : "0.0.0.0",
-    "log_aggregator_port" : "12201",
+        "console" : {
+            "enable" : true,
+            "level" : "INFO"
+        },
+        "logfile" : {
+            "enable" : true,
+            "level" : "VERBOSE",
+            "directory" : "/data/borealis_logs"
+        },
+        "aggregator" : {
+            "enable" : true,
+            "level" : "VERBOSE",
+            "addr" : "0.0.0.0",
+            "port" : "12201"
+        }
+    },
     "hdw_path" : "/usr/local/hdw"
 }

--- a/src/brian.py
+++ b/src/brian.py
@@ -149,21 +149,21 @@ def sequence_timing(options):
                 if TIME_PROFILE:
                     time_mark = time.perf_counter() - time_now
                     time_now = time.perf_counter()
-                    log.info(f"driver ready", driver_time=time_mark)
+                    log.verbose(f"driver ready", driver_time=time_mark)
                 want_to_start = True
 
             if message == "good_to_start":
                 if TIME_PROFILE:
                     time_mark = time.perf_counter() - time_now
                     time_now = time.perf_counter()
-                    log.info(f"copied to gpu", copy2gpu_time=time_mark)
+                    log.verbose(f"copied to gpu", copy2gpu_time=time_mark)
                 good_to_start = True
 
             if message == "extra_good_to_start":
                 if TIME_PROFILE:
                     time_mark = time.perf_counter() - time_now
                     time_now = time.perf_counter()
-                    log.info(f"dsp done with data", dsp_time=time_mark)
+                    log.verbose(f"dsp done with data", dsp_time=time_mark)
                 dsp_finish_counter = 1
 
     thread = threading.Thread(target=start_new)

--- a/src/data_write.py
+++ b/src/data_write.py
@@ -1137,10 +1137,10 @@ class DataWrite(object):
             write_tx_data()
 
         write_time = time.perf_counter() - start
-        log.info("write time",
+        log.info("wrote record",
                  write_time=write_time * 1e3,
-                 write_time_units='ms',
-                 dataset_name=dataset_name)
+                 time_units='ms',
+                 dataset_name=datetime_string)
 
 
 def main():

--- a/src/data_write.py
+++ b/src/data_write.py
@@ -1256,9 +1256,9 @@ def main():
                 start = time.perf_counter()
                 data_parsing.update(pd)
                 parse_time = time.perf_counter() - start
-                log.info("parse time",
-                         parse_time=parse_time * 1e3,
-                         parse_time_units='ms')
+                log.verbose("parse time",
+                            parse_time=parse_time * 1e3,
+                            parse_time_units='ms')
 
             queued_sqns = []
 

--- a/src/experiment_handler.py
+++ b/src/experiment_handler.py
@@ -28,8 +28,7 @@ from experiment_prototype.experiment_exception import ExperimentException
 from experiment_prototype.experiment_prototype import ExperimentPrototype
 
 from utils import log_config
-log = log_config.log(log_level='NOTSET', console=False, logfile=False, aggregator=False)
-
+log = log_config.log(console=False, logfile=False, aggregator=False)
 
 
 def usage_msg():

--- a/src/experiment_handler.py
+++ b/src/experiment_handler.py
@@ -14,21 +14,25 @@
     :copyright: 2018 SuperDARN Canada
     :author: Marci Detwiller
 """
-
-import zmq
-import sys
 import argparse
-import inspect
 import importlib
-import threading
+import inspect
+from pathlib import Path
 import pickle
+import sys
+import threading
+
+import structlog
+import zmq
+
 from utils.options import Options
 from utils import socket_operations
 from experiment_prototype.experiment_exception import ExperimentException
 from experiment_prototype.experiment_prototype import ExperimentPrototype
 
-from utils import log_config
-log = log_config.log(console=False, logfile=False, aggregator=False)
+caller = Path(inspect.stack()[-1].filename)
+module_name = caller.name.split('.')[0]
+log = structlog.getLogger(module_name)
 
 
 def usage_msg():
@@ -127,9 +131,9 @@ def retrieve_experiment(experiment_module_name):
     # this is the experiment class that we need to run.
     experiment = experiment_classes[0][1]
 
-    log.info("retrieving experiment from module",
-             experiment_class=experiment_classes[0][0],
-             experiment_module=experiment_mod)
+    log.verbose("retrieving experiment from module",
+                experiment_class=experiment_classes[0][0],
+                experiment_module=experiment_mod)
 
     return experiment
 

--- a/src/experiment_prototype/experiment_prototype.py
+++ b/src/experiment_prototype/experiment_prototype.py
@@ -968,13 +968,13 @@ class ExperimentPrototype:
                     if len(seq.slice_ids) > max_num_concurrent_slices:
                         max_num_concurrent_slices = len(seq.slice_ids)
 
-        log.info(f"Number of Scan types: {len(self.__scan_objects)}")
-        log.info(f"Number of AveragingPeriods in Scan #1: {len(self.__scan_objects[0].aveperiods)}")
-        log.info(f"Number of Sequences in Scan #1, Averaging Period #1: "
+        log.verbose(f"Number of Scan types: {len(self.__scan_objects)}")
+        log.verbose(f"Number of AveragingPeriods in Scan #1: {len(self.__scan_objects[0].aveperiods)}")
+        log.verbose(f"Number of Sequences in Scan #1, Averaging Period #1: "
                  f"{len(self.__scan_objects[0].aveperiods[0].sequences)}")
-        log.info(f"Number of Pulse Types in Scan #1, Averaging Period #1, Sequence #1: "
+        log.verbose(f"Number of Pulse Types in Scan #1, Averaging Period #1, Sequence #1: "
                  f"{len(self.__scan_objects[0].aveperiods[0].sequences[0].slice_dict)}")
-        log.info(f"Max concurrent slices: {max_num_concurrent_slices}")
+        log.verbose(f"Max concurrent slices: {max_num_concurrent_slices}")
 
     def get_slice_interfacing(self, slice_id):
         """

--- a/src/experiment_prototype/scan_classes/sequences.py
+++ b/src/experiment_prototype/scan_classes/sequences.py
@@ -166,11 +166,11 @@ class Sequence(ScanClassBase):
                 # main_phase_shift: [num_beams, num_antennas]
                 # basic_samples:    [num_samples]
                 # phased_samps_for_beams: [num_beams, num_antennas, num_samples]
-                log.info("slice information",
-                         slice_id=slice_id,
-                         tx_main_phases=tx_main_phase_shift,
-                         tx_main_magnitudes=np.abs(tx_main_phase_shift),
-                         tx_main_angles=np.rad2deg(np.angle(tx_main_phase_shift)))
+                log.verbose("slice information",
+                            slice_id=slice_id,
+                            tx_main_phases=tx_main_phase_shift,
+                            tx_main_magnitudes=np.abs(tx_main_phase_shift),
+                            tx_main_angles=np.rad2deg(np.angle(tx_main_phase_shift)))
                 phased_samps_for_beams = np.einsum('ij,k->ijk', tx_main_phase_shift, basic_samples)
                 self.basic_slice_pulses[slice_id] = phased_samps_for_beams
             else:
@@ -327,7 +327,7 @@ class Sequence(ScanClassBase):
         for i, cpm in enumerate(combined_pulses_metadata):
             # message = f"Pulse {i}: start time(us) {cpm['start_time_us']}  start sample {cpm['pulse_sample_start']}"
             # message += f"          pulse length(us) {cpm['total_pulse_len']}  pulse num samples {cpm['total_num_samps']}"
-            log.info("pulse information", **cpm)
+            log.verbose("pulse information", **cpm)
 
         self.combined_pulses_metadata = combined_pulses_metadata
 

--- a/src/radar_control.py
+++ b/src/radar_control.py
@@ -237,9 +237,9 @@ def send_dsp_metadata(radctrl_to_dsp, dsp_radctrl_iden, radctrl_to_brian, brian_
 
     if TIME_PROFILE:
         time_done = time.perf_counter() - time_waiting
-        log.info("waiting time for metadata request",
-                 metadata_time=time_done * 1e3,
-                 metadata_time_units='ms')
+        log.verbose("waiting time for metadata request",
+                    metadata_time=time_done * 1e3,
+                    metadata_time_units='ms')
 
     bytes_packet = pickle.dumps(message, protocol=pickle.HIGHEST_PROTOCOL)
 
@@ -604,7 +604,7 @@ def main():
                 # Time to start averaging in the below loop.
                 if not scan.scanbound:
                     averaging_period_start_time = datetime.utcnow()  # ms
-                    log.info("averaging period start time",
+                    log.verbose("averaging period start time",
                              averaging_period_start_time=averaging_period_start_time,
                              averaging_period_start_time_units='')
                 if aveperiod.intt is not None:
@@ -618,7 +618,7 @@ def main():
                         time_diff = beam_scanbound - datetime.utcnow()
                         if time_diff.total_seconds() > 0:
                             if first_aveperiod:
-                                log.info("seconds to next avg period",
+                                log.verbose("seconds to next avg period",
                                          time_until_avg_period=time_diff.total_seconds(),
                                          time_until_avg_period_units='s',
                                          scan_iter=scan_iter,
@@ -640,7 +640,7 @@ def main():
                                       beam_scanbound=beam_scanbound)
 
                         averaging_period_start_time = datetime.utcnow()
-                        log.info("avg period start time",
+                        log.verbose("avg period start time",
                                  avg_period_start_time=averaging_period_start_time,
                                  avg_period_start_time_units='s',
                                  scan_iter=scan_iter,
@@ -663,7 +663,7 @@ def main():
                             bound_time_remaining = next_scan_start - averaging_period_start_time
                             bound_time_remaining = bound_time_remaining.total_seconds()
 
-                        log.info("bound time remaining",
+                        log.verbose("bound time remaining",
                                  bound_time_remaining=bound_time_remaining,
                                  bound_time_remaining_units='s',
                                  scan_num=scan_num,
@@ -688,13 +688,13 @@ def main():
                     ending_number_of_sequences = aveperiod.intn  # this will exist
 
                 msg = {x: y[aveperiod.beam_iter] for x, y in aveperiod.slice_to_beamorder.items()}
-                log.info("avg period slice and beam number", slice_and_beam=msg)
+                log.verbose("avg period slice and beam number", slice_and_beam=msg)
 
                 if TIME_PROFILE:
                     aveperiod_prep_time = datetime.utcnow() - time_start_of_aveperiod
-                    log.info("time to prep aveperiod",
-                             aveperiod_prep_time=aveperiod_prep_time,
-                             aveperiod_prep_time_units='')
+                    log.verbose("time to prep aveperiod",
+                                aveperiod_prep_time=aveperiod_prep_time,
+                                aveperiod_prep_time_units='')
 
                 #  Time to start averaging in the below loop
                 num_sequences = 0
@@ -747,9 +747,9 @@ def main():
 
                             if TIME_PROFILE:
                                 pulses_to_driver_time = datetime.utcnow() - start_time
-                                log.info("pulses to driver time",
-                                         pulses_to_driver_time=pulses_to_driver_time,
-                                         pulses_to_driver_time_units='s')
+                                log.verbose("pulses to driver time",
+                                            pulses_to_driver_time=pulses_to_driver_time,
+                                            pulses_to_driver_time_units='s')
 
                         def send_dsp_meta():
                             rx_beam_phases = sequence.get_rx_phases(aveperiod.beam_iter)
@@ -769,9 +769,9 @@ def main():
 
                             if TIME_PROFILE:
                                 sequence_metadata_time = datetime.utcnow() - start_time
-                                log.info("metadata to dsp time",
-                                         sequence_metadata_time=sequence_metadata_time,
-                                         sequence_metadata_time_units='s')
+                                log.verbose("metadata to dsp time",
+                                            sequence_metadata_time=sequence_metadata_time,
+                                            sequence_metadata_time_units='s')
 
                         def make_next_samples():
                             sqn, dbg = sequence.make_sequence(aveperiod.beam_iter, num_sequences + 1)
@@ -781,9 +781,9 @@ def main():
 
                             if TIME_PROFILE:
                                 new_sequence_time = datetime.utcnow() - start_time
-                                log.info("make new sequence time",
-                                         new_sequence_time=new_sequence_time,
-                                         new_sequence_time_units='s')
+                                log.verbose("make new sequence time",
+                                            new_sequence_time=new_sequence_time,
+                                            new_sequence_time_units='s')
 
                         # These three things can happen simultaneously. We can spawn them as threads.
                         threads = [threading.Thread(target=send_pulses),
@@ -808,9 +808,9 @@ def main():
 
                 if TIME_PROFILE:
                     avg_period_end_time = datetime.utcnow()
-                    log.info("avg period end time",
-                             avg_period_end_time=avg_period_end_time,
-                             avg_period_end_time_units='s')
+                    log.verbose("avg period end time",
+                                avg_period_end_time=avg_period_end_time,
+                                avg_period_end_time_units='s')
 
                 log.info("sequences in avg period", num_sequences=num_sequences)
 
@@ -845,9 +845,9 @@ def main():
 
                 if TIME_PROFILE:
                     time_to_finish_aveperiod = datetime.utcnow() - avg_period_end_time
-                    log.info("time to finish avg period",
-                             avg_period_elapsed_time=time_to_finish_aveperiod,
-                             avg_period_elapsed_time_units='s')
+                    log.verbose("time to finish avg period",
+                                avg_period_elapsed_time=time_to_finish_aveperiod,
+                                avg_period_elapsed_time_units='s')
 
                 aveperiod.beam_iter += 1
                 if aveperiod.beam_iter == aveperiod.num_beams_in_scan:

--- a/src/realtime.py
+++ b/src/realtime.py
@@ -42,7 +42,7 @@ def main():
             # TODO: Make sure we only process the first slice for simultaneous multi-slice data for now
             try:
                 record = sorted(list(rawacf_data.keys()))[0]
-                log.info("using pydarnio to convert", record=record)
+                log.info("converting record", record=record)
                 converted = pydarnio.BorealisConvert.\
                     _BorealisConvert__convert_rawacf_record(0, (record, rawacf_data[record]), "")
             except pydarnio.borealis_exceptions.BorealisConvert2RawacfError:
@@ -53,7 +53,7 @@ def main():
                 fit_data = fitacf._fit(rec)
                 tmp = fit_data.copy()
 
-                # Can't jsonify numpy so we convert to native types for realtime purposes.
+                # Can't jsonify numpy, so we convert to native types for realtime purposes.
                 for k, v in fit_data.items():
                     if hasattr(v, 'dtype'):
                         if isinstance(v, np.ndarray):

--- a/src/rx_signal_processing.py
+++ b/src/rx_signal_processing.py
@@ -466,9 +466,9 @@ def main():
                 dm_rates.append(stage.dm_rate)
                 dm_scheme_taps.append(np.array(stage.filter_taps, dtype=np.complex64))
                 taps_per_stage.append(len(stage.filter_taps))
-            log.info("stage decimation and filter taps",
-                     decimation_rates=dm_rates,
-                     filter_taps_per_stage=taps_per_stage)
+            log.verbose("stage decimation and filter taps",
+                        decimation_rates=dm_rates,
+                        filter_taps_per_stage=taps_per_stage)
 
             dm_rates = np.array(dm_rates, dtype=np.uint32)
 
@@ -588,15 +588,15 @@ def main():
             log_dict["dsp_end_msg_time"] = (time.perf_counter() - mark_timer) * 1e3
 
             log_dict["total_sequence_process_time"] = (time.perf_counter() - start_timer) * 1e3
-            log.info("processing sequence",
-                     sequence_num=sequence_num,
-                     mixing_freqs=mixing_freqs,
-                     mixing_freqs_units='Hz',
-                     main_beam_angles=main_beam_angles.shape,
-                     intf_beam_angles=main_beam_angles.shape,
-                     main_buffer_shape=main_sequence_samples_shape,
-                     intf_buffer_shape=intf_sequence_samples_shape,
-                     **log_dict)
+            log.verbose("processing sequence",
+                        sequence_num=sequence_num,
+                        mixing_freqs=mixing_freqs,
+                        mixing_freqs_units='Hz',
+                        main_beam_angles=main_beam_angles.shape,
+                        intf_beam_angles=main_beam_angles.shape,
+                        main_buffer_shape=main_sequence_samples_shape,
+                        intf_buffer_shape=intf_sequence_samples_shape,
+                        **log_dict)
 
             # Generate a new timer dict for a uniform log
             log_dict = {"time_units": "ms"}
@@ -702,9 +702,11 @@ def main():
             so.send_bytes(dsp_to_dw, options.dw_to_dsp_identity, sqn_message)
 
             log_dict["total_serialize_send_time"] = (time.perf_counter() - start_timer) * 1e3
-            log.info("processing sequence",
-                     sequence_num=sequence_num,
-                     **log_dict)
+            log.info("done with sequence",
+                     sequence_num=sequence_num)
+            log.verbose("sequence timing",
+                        sequence_num=sequence_num,
+                        **log_dict)
 
         args = {"sequence_num": copy.deepcopy(sqn_meta_message.sequence_num),
                 "main_beam_angles": copy.deepcopy(main_beam_angles),

--- a/src/utils/log_config.py
+++ b/src/utils/log_config.py
@@ -202,9 +202,6 @@ def log(console_log_level=None, logfile_log_level=None, aggregator_log_level=Non
         console = options.log_console_bool
     if logfile is None:
         logfile = options.log_logfile_bool
-        # Set the log file and dir path. The time tag will be appended at the midnight
-        # roll over by the TimedRotatingLogHandler.
-        log_file = f"{options.log_directory}/{module_name}"
     if aggregator is None:
         aggregator = options.log_aggregator_bool
 
@@ -282,6 +279,9 @@ def log(console_log_level=None, logfile_log_level=None, aggregator_log_level=Non
 
     # Set up the second handler to pipe logs to a JSON file that rotates at midnight
     if logfile:
+        # Set the log file and dir path. The time tag will be appended at the midnight
+        # roll over by the TimedRotatingLogHandler.
+        log_file = f"{options.log_directory}/{module_name}"
         logfile_handler = TimedRotatingFileHandler(filename=log_file, when='midnight', utc=True)
         logfile_handler.setFormatter(structlog.stdlib.ProcessorFormatter(
             foreign_pre_chain=shared_processors,  # These run on logs that do not come from structlog

--- a/src/utils/options.py
+++ b/src/utils/options.py
@@ -31,7 +31,9 @@ class Options:
     log_aggregator_port: int = field(init=False)
     log_console_bool: bool = field(init=False)
     log_directory: str = field(init=False)
-    log_level: str = field(init=False)
+    console_log_level: str = field(init=False)
+    logfile_log_level: str = field(init=False)
+    aggregator_log_level: str = field(init=False)
     log_logfile_bool: bool = field(init=False)
     main_antennas: list[int] = field(init=False)
     main_antenna_spacing: float = field(init=False)
@@ -195,15 +197,17 @@ class Options:
         self.ringbuffer_name = raw_config["ringbuffer_name"]
 
         self.data_directory = raw_config["data_directory"]
-        self.log_directory = raw_config["log_directory"]
+        self.log_directory = raw_config["log_handlers"]["logfile"]["directory"]
         self.hdw_path = raw_config['hdw_path']
 
-        self.log_level = raw_config["log_level"]
-        self.log_console_bool = raw_config["log_handlers"]["console"]
-        self.log_logfile_bool = raw_config["log_handlers"]["logfile"]
-        self.log_aggregator_bool = raw_config["log_handlers"]["aggregator"]
-        self.log_aggregator_addr = raw_config["log_aggregator_addr"]
-        self.log_aggregator_port = int(raw_config["log_aggregator_port"])
+        self.console_log_level = raw_config["log_handlers"]["console"]["level"]
+        self.logfile_log_level = raw_config["log_handlers"]["logfile"]["level"]
+        self.aggregator_log_level = raw_config["log_handlers"]["aggregator"]["level"]
+        self.log_console_bool = raw_config["log_handlers"]["console"]["enable"]
+        self.log_logfile_bool = raw_config["log_handlers"]["logfile"]["enable"]
+        self.log_aggregator_bool = raw_config["log_handlers"]["aggregator"]["enable"]
+        self.log_aggregator_addr = raw_config["log_handlers"]["aggregator"]["addr"]
+        self.log_aggregator_port = int(raw_config["log_handlers"]["aggregator"]["port"])
 
     def parse_hdw(self):
         # Load information from the hardware file

--- a/tests/experiments/experiment_unittests.py
+++ b/tests/experiments/experiment_unittests.py
@@ -309,7 +309,7 @@ def run_tests(raw_args=None, buffer=True, print_results=True):
 
     # These directories are required for ExperimentHandler to run
     data_directory = raw_config["data_directory"]
-    log_directory = raw_config["log_directory"]
+    log_directory = raw_config["log_handlers"]["logfile"]["directory"]
     hdw_path = raw_config['hdw_path']
     hdw_dat_file = f'{hdw_path}/hdw.dat.{os.environ["RADAR_ID"]}'
     if not os.path.exists(data_directory):

--- a/tests/experiments/experiment_unittests.py
+++ b/tests/experiments/experiment_unittests.py
@@ -322,12 +322,13 @@ def run_tests(raw_args=None, buffer=True, print_results=True):
         open(hdw_dat_file, 'w')
 
     experiments = args.experiments
-    print(f"Running tests on experiments {experiments}")
     if experiments is None:  # Run all unit tests and experiment tests
+        print("Running tests on all experiments")
         build_unit_tests()
         build_experiment_tests()
         argv = [sys.argv[0]]
     else:  # Only test specified experiments
+        print(f"Running tests on experiments {experiments}")
         build_experiment_tests(experiments, args.kwargs)
         exp_tests = []
         for exp in experiments:
@@ -368,4 +369,7 @@ def run_tests(raw_args=None, buffer=True, print_results=True):
 
 
 if __name__ == '__main__':
+    from utils import log_config
+    log = log_config.log(console=False, logfile=False, aggregator=False)
+
     run_tests(sys.argv[1:])

--- a/tests/log_printer/json_to_rich_logs.py
+++ b/tests/log_printer/json_to_rich_logs.py
@@ -1,0 +1,76 @@
+"""
+    json_to_rich_logs
+    ~~~~~~~~~~~~~~~~~
+    A script for converting JSON-rendered Borealis logfiles to console-rendered logfiles.
+    This script will replicate the logs that display in screens when steamed_hams.py is run.
+"""
+import argparse
+import os
+import sys
+
+import ijson
+
+
+def add_item(container, k, v):
+    if isinstance(container, dict):
+        key = k.split('.')[-1]
+        container[key] = v
+    elif isinstance(container, list):
+        container.append(v)
+    else:
+        raise RuntimeError(f"Unable to add to current object: unsupported type {type(nest_list[-1])}")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('json_file', type=str, help='Path to JSON log file')
+    parser.add_argument('outfile', type=str, help='Path for new file')
+    args = parser.parse_args()
+
+    sys.path.append(os.environ['BOREALISPATH'])
+    from src.utils import log_config
+
+    log = log_config.log(
+        console=False,
+        logfile=False,
+        aggregator=False,
+        json_to_console_file=args.outfile,
+    )
+
+    with open(args.json_file, 'rb') as stream:
+        json_parser = ijson.parse(stream, use_float=True, multiple_values=True)
+
+        nest_list = []
+        prefix_list = []
+        for prefix, event, value in json_parser:
+            if event == 'start_map':
+                nest_list.append({})
+            elif event == 'end_map':
+                if len(nest_list) == 0:
+                    raise RuntimeError("JSON closing } found without opening {")
+                current_entry = nest_list.pop()
+                if len(nest_list) > 0:
+                    add_item(nest_list[-1], prefix, current_entry)
+                else:
+                    level = current_entry.pop('level', None)
+                    msg = current_entry.pop('event', '')
+                    if level == 'info':
+                        log.info(msg, **current_entry)
+                    elif level == 'debug':
+                        log.debug(msg, **current_entry)
+                    elif level == 'warning':
+                        log.warning(msg, **current_entry)
+                    elif level == 'critical':
+                        log.critical(msg, **current_entry)
+                    else:
+                        raise ValueError(f"Unknown log level: {level}")
+            elif event == 'start_array':
+                nest_list.append([])
+            elif event == 'end_array':
+                current_entry = nest_list.pop()
+                nest_list[-1][prefix] = current_entry
+            elif event not in ['', 'map_key'] and prefix != '':
+                if len(nest_list) == 0:
+                    add_item(nest_list, prefix, value)
+                else:
+                    add_item(nest_list[-1], prefix, value)


### PR DESCRIPTION
Some significant changes to how logging is handled in Borealis.

* Created a script for converting JSON-rendered logfiles to console-style logs. This was requested by @tjk584 for ease of reading after-the-fact.
* Added a new logging level: `VERBOSE`, which fits between `DEBUG` and `INFO`. This was also requested by @tjk584. This has been used in place of `INFO` for most logging calls, and the log level set to `INFO` for the console and `VERBOSE` for logfile and aggregator handlers.
* Modified the config file format to group the log fields together and add handler-specific log level fields.
* Modified experiment_unittests.py to use its own log instance, with no renderer. This allowed for the log instance created at the module level of experiment_handler.py to be replaced by a getLogger() call.