### PR TITLE
Correct determination of lines to schedule

### DIFF
--- a/scheduler/quick_test_scdutils.py
+++ b/scheduler/quick_test_scdutils.py
@@ -4,21 +4,21 @@ import scd_utils
 if __name__ == "__main__":
     filename = sys.argv[1]
 
-    scd_util = SCDUtils(filename)
+    scd_util = scd_utils.SCDUtils(filename)
 
-    scd_util.add_line("20190404", "10:43", "twofsound")
+    scd_util.add_line("20190404", "10:43", "twofsound", 'common')
     #scd_util.add_line("04/04/2019", "10:43", "twofsound")
-    scd_util.add_line("20190407", "10:43", "twofsound")
-    scd_util.add_line("20190414", "10:43", "twofsound")
-    scd_util.add_line("20190414", "10:43", "twofsound", prio=2)
-    scd_util.add_line("20190414", "10:43", "twofsound", prio=1, duration=89)
+    scd_util.add_line("20190407", "10:43", "twofsound", 'common')
+    scd_util.add_line("20190414", "10:43", "twofsound", 'common')
+    scd_util.add_line("20190414", "10:43", "twofsound", 'common', prio=1, duration='89')
     #scd_util.add_line("20190414", "10:43", "twofsound", prio=1, duration=24)
-    scd_util.add_line("20190414", "11:43", "twofsound", duration=46)
-    scd_util.add_line("20190414", "00:43", "twofsound")
-    scd_util.add_line("20190408", "15:43", "twofsound", duration=57)
+    scd_util.add_line("20190414", "11:43", "twofsound", 'common', duration='46')
+    scd_util.add_line("20190414", "00:43", "twofsound", 'common')
+    scd_util.add_line("20190408", "15:43", "twofsound", 'common', duration='57')
 
 
-    scd_util.remove_line("20190414", "10:43", "twofsound")
+    scd_util.remove_line("20190414", "10:43", "twofsound", 'common')
 
-    print(scd_util.get_relevant_lines("20190414", "10:44"))
+    for line in scd_util.get_relevant_lines("20190414", "10:44"):
+        print(line)
 

--- a/scheduler/remote_server.py
+++ b/scheduler/remote_server.py
@@ -329,48 +329,6 @@ def timeline_to_atq(timeline, scd_dir, time_of_interest, site_id):
     return sp.check_output(get_atq_cmd, shell=True)
 
 
-def get_relevant_lines(scd_util, time_of_interest):
-    """
-    Gets the relevant lines.
-
-    Does a search for relevant lines. If the first line returned isn't an infinite duration, we need
-    to look back until we find an infinite duration line, as that should be the last line to
-    continue running if we need it.
-
-    :param  scd_util:           The scd utility object that holds the scd lines.
-    :type   scd_util:           SCDUtils
-    :param  time_of_interest:   Time to get relevant lines for
-    :type   time_of_interest:   Datetime
-
-    :returns:   The relevant lines.
-    :rtype:     list(dict)
-    """
-
-    found = False
-    time = time_of_interest
-
-    yyyymmdd = time_of_interest.strftime("%Y%m%d")
-    hhmm = time_of_interest.strftime("%H:%M")
-
-    relevant_lines = scd_util.get_relevant_lines(yyyymmdd, hhmm)
-    while not found:
-
-        first_time_lines = [x for x in relevant_lines if x['timestamp'] == relevant_lines[0]['timestamp']]
-        for line in first_time_lines:
-            if line['duration'] == '-':
-                found = True
-
-        if not found:
-            time -= datetime.timedelta(minutes=1)
-
-            yyyymmdd = time.strftime("%Y%m%d")
-            hhmm = time.strftime("%H:%M")
-
-            relevant_lines = scd_util.get_relevant_lines(yyyymmdd, hhmm)
-
-    return relevant_lines
-
-
 def _main():
     """ """
     parser = argparse.ArgumentParser(description="Automatically schedules new SCD file entries")
@@ -412,7 +370,9 @@ def _main():
 
         log_msg_header = f"Updated at {time_of_interest}\n"
         try:
-            relevant_lines = get_relevant_lines(scd_util, time_of_interest)
+            yyyymmdd = time_of_interest.strftime("%Y%m%d")
+            hhmm = time_of_interest.strftime("%H:%M")
+            relevant_lines = scd_util.get_relevant_lines(yyyymmdd, hhmm)
         except (IndexError, ValueError) as e:
             logtime = time_of_interest.strftime("%c")
             error_msg = f"{logtime}: Unable to make schedule\n\t Exception thrown:\n\t\t {str(e)}\n"

--- a/scheduler/scd_utils.py
+++ b/scheduler/scd_utils.py
@@ -333,9 +333,7 @@ class SCDUtils:
         relevant_lines = []
         past_infinite_line_added = False
         for line in reversed(scd_lines):
-            if line['timestamp'] > epoch_milliseconds:
-                relevant_lines.append(line)
-            elif line['timestamp'] == epoch_milliseconds:
+            if line['timestamp'] >= epoch_milliseconds:
                 relevant_lines.append(line)
             else:
                 # Include the most recent infinite line

--- a/scheduler/scd_utils.py
+++ b/scheduler/scd_utils.py
@@ -99,6 +99,9 @@ class SCDUtils(object):
             if isinstance(duration, float) or int(duration) < 1:
                 raise ValueError("Duration should be an integer > 0, or '-'")
             duration = int(duration)
+        else:
+            if int(prio) > 0:
+                raise ValueError("Infinite duration lines must have priority 0")
 
         epoch = dt.datetime.utcfromtimestamp(0)
         epoch_milliseconds = int((time - epoch).total_seconds() * 1000)
@@ -291,9 +294,9 @@ class SCDUtils(object):
         """
         Gets the currently scheduled and future lines given a supplied time. If the provided time is
         equal to a scheduled line time, it provides that line and all future lines. If the provided
-        time is between schedule line times, it provides any lines in the schedule with the most
-        recent timestamp and all future lines.  If the provided time is before any lines in the
-        schedule, it provides all schedule lines.
+        time is between schedule line times, it provides any lines in the schedule from the past that
+        haven't ended yet, plus the most recently timestamped infinite-duration line, plus all future
+        lines. If the provided time is before any lines in the schedule, it provides all schedule lines.
 
         :param  yyyymmdd:   year/month/day string.
         :type   yyyymmdd:   str
@@ -315,35 +318,38 @@ class SCDUtils(object):
 
         scd_lines = self.read_scd()
 
+        # Sort the lines by timestamp, and for equal times, in reverse priority
+        scd_lines = sorted(scd_lines, key=lambda x: x['prio'], reverse=True)
+        scd_lines = sorted(scd_lines, key=lambda x: x['timestamp'])
+
         if not scd_lines:
             raise IndexError("Schedule file is empty. No lines can be returned")
 
         epoch = dt.datetime.utcfromtimestamp(0)
         epoch_milliseconds = int((time - epoch).total_seconds() * 1000)
 
-        equals = False
-        prev_line_appended = False
         relevant_lines = []
-        for idx, line in enumerate(scd_lines):
-            if line['timestamp'] == epoch_milliseconds:
-                equals = True
+        past_infinite_line_added = False
+        for line in reversed(scd_lines):
+            if line['timestamp'] > epoch_milliseconds:
                 relevant_lines.append(line)
-            elif line['timestamp'] > epoch_milliseconds:
-                if equals:
-                    relevant_lines.append(line)
-                else:
-                    if not prev_line_appended:
-                        if idx != 0:
-                            last_line_timestamp = scd_lines[idx-1]['timestamp']
-                            temp_list = scd_lines[:]
-                            for t in temp_list:
-                                if t['timestamp'] == last_line_timestamp:
-                                    relevant_lines.append(t)
-                        prev_line_appended = True
-                    relevant_lines.append(line)
+            elif line['timestamp'] == epoch_milliseconds:
+                relevant_lines.append(line)
             else:
-                continue
+                # Include the most recent infinite line
+                if line['duration'] == '-':
+                    if not past_infinite_line_added:
+                        relevant_lines.append(line)
+                        past_infinite_line_added = True
+                else:
+                    # If the line ends after the current time, include the line
+                    duration_ms = int(line['duration']) * 60 * 1000
+                    line_end = line['timestamp'] + duration_ms
+                    if line_end >= epoch_milliseconds:
+                        relevant_lines.append(line)
 
+        # Put the lines into chronological order (oldest to newest)
+        relevant_lines.reverse()
         return relevant_lines
 
 

--- a/scheduler/scd_utils.py
+++ b/scheduler/scd_utils.py
@@ -37,25 +37,26 @@ def get_next_month_from_date(date=None):
     return new_date
 
 
-class SCDUtils(object):
+class SCDUtils:
     """
     Contains utilities for working with SCD files. SCD files are schedule files for Borealis.
-    
-    :param  scd_filename:   Schedule file name
-    :type:  scd_filename:   str
-    :param  scd_dt_fmt:     String format for parsing/writing datetimes.
-    :type:  scd_dt_fmt:     str
-    :param  line_fmt:       String format for scd line.
-    :type:  line_fmt:       str
-    :param  scd_default:    Default event to run if no other infinite duration line is scheduled.
-    :type:  scd_default:    dict
     """
 
+    """String format for parsing and writing datetimes"""
+    scd_dt_fmt = "%Y%m%d %H:%M"
+
+    """String format for scd line"""
+    line_fmt = "{datetime} {duration} {prio} {experiment} {scheduling_mode} {embargo} {kwargs}"
+
+
     def __init__(self, scd_filename):
-        super().__init__()
+        """
+        :param  scd_filename:   Schedule file name
+        :type:  scd_filename:   str
+        """
         self.scd_filename = scd_filename
-        self.scd_dt_fmt = "%Y%m%d %H:%M"
-        self.line_fmt = "{datetime} {duration} {prio} {experiment} {scheduling_mode} {embargo} {kwargs}"
+
+        """Default event to run if no other infinite duration line is scheduled"""
         self.scd_default = self.check_line('20000101', '00:00', 'normalscan', 'common', '0', '-')
 
     def check_line(self, yyyymmdd, hhmm, experiment, scheduling_mode, prio, duration, kwargs='', embargo=False):
@@ -169,7 +170,8 @@ class SCDUtils(object):
 
         return scd_lines
 
-    def fmt_line(self, line_dict):
+    @classmethod
+    def fmt_line(cls, line_dict):
         """
         Formats a dictionary with line info into a text line for file.
 
@@ -179,13 +181,13 @@ class SCDUtils(object):
         :returns:   Formatted string.
         :rtype:     str
         """
-        line_str = self.line_fmt.format(datetime=line_dict["time"].strftime(self.scd_dt_fmt),
-                                        prio=line_dict["prio"],
-                                        experiment=line_dict["experiment"],
-                                        scheduling_mode=line_dict["scheduling_mode"],
-                                        duration=line_dict["duration"],
-                                        embargo='--embargo' if line_dict["embargo"] else '',
-                                        kwargs=line_dict["kwargs"])
+        line_str = cls.line_fmt.format(datetime=line_dict["time"].strftime(cls.scd_dt_fmt),
+                                       prio=line_dict["prio"],
+                                       experiment=line_dict["experiment"],
+                                       scheduling_mode=line_dict["scheduling_mode"],
+                                       duration=line_dict["duration"],
+                                       embargo='--embargo' if line_dict["embargo"] else '',
+                                       kwargs=line_dict["kwargs"])
         return line_str
 
     def write_scd(self, scd_lines):
@@ -255,7 +257,7 @@ class SCDUtils(object):
         self.write_scd(new_scd)
 
     def remove_line(self, yyyymmdd, hhmm, experiment, scheduling_mode, prio=0, 
-                    duration='-', kwargs='', embargo=''):
+                    duration='-', kwargs='', embargo=False):
         """
         Removes a line from the schedule
 

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -55,12 +55,12 @@ class TestSchedulerUtils(unittest.TestCase):
         time_of_interest = datetime.datetime(2000, 1, 1, 6, 30)
         time_of_interest2 = datetime.datetime(2022, 4, 5, 16, 56)
         self.linedict = {"time": time_of_interest, "prio": 0, "experiment": 'normalscan', "scheduling_mode": 'common',
-                         "duration": 60, "kwargs_string": '-'}
-        self.linestr = "20000101 06:30 60 0 normalscan common -\n"
+                         "duration": 60, "kwargs": '-', 'embargo': False}
+        self.linestr = "20000101 06:30 60 0 normalscan common  -\n"
         self.linedict2 = {"time": time_of_interest2, "prio": 15, "experiment": 'twofsound',
                           "scheduling_mode": 'discretionary', "duration": 360,
-                          "kwargs_string": 'freq1=10500 freq2=13100'}
-        self.linestr2 = "20220405 16:56 360 15 twofsound discretionary freq1=10500 freq2=13100\n"
+                          "kwargs": 'freq1=10500 freq2=13100', 'embargo': False}
+        self.linestr2 = "20220405 16:56 360 15 twofsound discretionary  freq1=10500 freq2=13100\n"
         self.maxDiff = None
 
     def setUp(self):
@@ -238,7 +238,7 @@ class TestSchedulerUtils(unittest.TestCase):
         Test an invalid number of arguments, requires 6 or 7 args
         """
         scdu = scd_utils.SCDUtils(self.incorrect_args_scd)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(IndexError):
             scdu.read_scd()
 
     def test_bad_scd_file(self):
@@ -416,8 +416,8 @@ class TestSchedulerUtils(unittest.TestCase):
         """
         scd_file = tempfile.NamedTemporaryFile(mode='w+t', delete=False)
         scdu = scd_utils.SCDUtils(scd_file.name)
-        scd_lines = ["20200917 00:00 - 0 normalscan common \n", "20200921 00:00 - 0 normalscan discretionary \n",
-                     "20200924 00:00 - 0 normalscan common freq1=10500\n", "20200926 00:00 - 0 normalscan common \n"]
+        scd_lines = ["20200917 00:00 - 0 normalscan common  \n", "20200921 00:00 - 0 normalscan discretionary  \n",
+                     "20200924 00:00 - 0 normalscan common  freq1=10500\n", "20200926 00:00 - 0 normalscan common  \n"]
         l0 = scd_lines[0].split()
         l1 = scd_lines[1].split()
         l2 = scd_lines[2].split()
@@ -527,7 +527,7 @@ class TestSchedulerUtils(unittest.TestCase):
         scd_file = tempfile.NamedTemporaryFile(mode='w+t', delete=False)
         scd_file.close()
         scdu = scd_utils.SCDUtils(scd_file.name)
-        self.assertEqual(scdu.get_relevant_lines("20061101", "00:00"), [])
+        self.assertEqual(scdu.get_relevant_lines("20061101", "00:00"), [scdu.scd_default])
 
     def test_empty_file_w_default(self):
         """
@@ -546,7 +546,7 @@ class TestSchedulerUtils(unittest.TestCase):
         """
         scdu = scd_utils.SCDUtils(self.good_scd_file)
         lines = scdu.get_relevant_lines("21001113", "00:00")
-        self.assertEqual(len(lines), 0)
+        self.assertEqual(len(lines), 1)
 
     def test_one_line_relevant(self):
         """
@@ -589,7 +589,7 @@ class TestSchedulerUtils(unittest.TestCase):
         self.assertEqual(lines[1]['prio'], '0')
         self.assertEqual(lines[1]['experiment'], 'twofsound')
         self.assertEqual(lines[1]['scheduling_mode'], 'common')
-        self.assertEqual(lines[1]['kwargs_string'], 'freq=10500')
+        self.assertEqual(lines[1]['kwargs'], 'freq=10500')
 
         self.assertEqual(lines[2]['duration'], '60')
         self.assertEqual(lines[2]['prio'], '2')
@@ -625,7 +625,7 @@ class TestSchedulerUtils(unittest.TestCase):
         self.assertEqual(lines[2]['prio'], '0')
         self.assertEqual(lines[2]['experiment'], 'twofsound')
         self.assertEqual(lines[2]['scheduling_mode'], 'common')
-        self.assertEqual(lines[2]['kwargs_string'], 'freq=10500')
+        self.assertEqual(lines[2]['kwargs'], 'freq=10500')
 
         self.assertEqual(lines[3]['duration'], '60')
         self.assertEqual(lines[3]['prio'], '2')
@@ -661,7 +661,7 @@ class TestSchedulerUtils(unittest.TestCase):
         self.assertEqual(lines[2]['prio'], '0')
         self.assertEqual(lines[2]['experiment'], 'twofsound')
         self.assertEqual(lines[2]['scheduling_mode'], 'common')
-        self.assertEqual(lines[2]['kwargs_string'], 'freq=10500')
+        self.assertEqual(lines[2]['kwargs'], 'freq=10500')
 
         self.assertEqual(lines[3]['duration'], '60')
         self.assertEqual(lines[3]['prio'], '2')


### PR DESCRIPTION
`remote_server.py` was testing thousands of schedule lines trying to determine the correct experiment to run. This PR fixes this problem by removing the offending function and fixing the function in `scd_utils.py` that was behaving incorrectly.

* `get_relevant_lines()` of `remote_server.py` was conducting a minute-by-minute search, rather than stepping through the entries of the schedule file. This function has been removed.
* `get_relevant_lines()` of `scd_utils.py` was updated to grab all future and current lines, as well as any past lines that run past the current time, and the most recent infinite-duration line from the past.
* Added in a check to ensure that infinite-duration lines have priority zero (otherwise, they would supersede any lower-priority experiments scheduled after them, essentially removing those lower priority levels).