### PR TITLE
Bugfix/filter correction

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,12 +8,12 @@ sphinxcontrib-autoprogram
 pyzmq
 myst_parser
 deepdish
-docutils==0.18
+docutils==0.16
 posix_ipc
 latex
 inotify
 matplotlib
-sphinx-rtd-theme==0.5.0
+sphinx-rtd-theme==0.5.1
 structlog
 h5py
 pydantic<=1.10.13

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,7 +8,7 @@ sphinxcontrib-autoprogram
 pyzmq
 myst_parser
 deepdish
-docutils<0.19
+docutils==0.18
 posix_ipc
 latex
 inotify

--- a/src/utils/signals.py
+++ b/src/utils/signals.py
@@ -157,7 +157,7 @@ class DSP:
         for idx, f in enumerate(mixing_freqs):
             # Filtering is actually done via a correlation, not a convolution (the filter is not reversed).
             # Thus, the mixing frequency should be the negative of the frequency that is actually being extracted.
-            bandpass[idx, :] = filter_taps[0] * np.exp(s * 2j * np.pi * (-1.0 * f) / rx_rate)
+            bandpass[idx, :] = filter_taps[0] * np.exp(s * 2j * np.pi * (-f) / rx_rate)
         filters.append(xp.array(bandpass, dtype=xp.complex64))
 
         for t in filter_taps[1:]:
@@ -229,7 +229,7 @@ class DSP:
         # [1, num_output_samples]
         # [num_slices, 1]
         # ph: [num_slices, num_output_samples]
-        ph = xp.fmod(ph * 2.0 * xp.pi * freqs / rx_rate * dm_rate, 2.0 * xp.pi)
+        ph = xp.fmod(ph * 2.0 * xp.pi * (-freqs) / rx_rate * dm_rate, 2.0 * xp.pi)
         ph = xp.exp(1j * ph.astype(xp.float32))
 
         # [num_slices, num_antennas, num_output_samples]


### PR DESCRIPTION
Fixed an error introduced by #441, where I missed inverting the mixing frequencies when correcting the phase of the output samples after the bandpass filter.