### PR TITLE
Fix docs and sort interfaced slices.

### DIFF
--- a/docs/source/experiment_prototype.rst
+++ b/docs/source/experiment_prototype.rst
@@ -24,9 +24,9 @@ Experiment Prototype Package
     :undoc-members:
     :show-inheritance:
 
-------------------
+-----------------------
 Interface Class Package
-------------------
+-----------------------
 
 .. automodule:: src.experiment_prototype.interface_classes.interface_class_base
     :members:

--- a/src/experiment_prototype/interface_classes/interface_class_base.py
+++ b/src/experiment_prototype/interface_classes/interface_class_base.py
@@ -183,7 +183,7 @@ class InterfaceClassBase(object):
                                               f"{bad_slices}")
             disjoint_sets[i] = sorted(list(disjoint_sets[i]))   # Convert to a list
 
-        disjoint_sets.sort(key=lambda x: x[0])
+        disjoint_sets.sort(key=lambda x: x[0])    # Sort by the first key in each list
         return disjoint_sets
 
     def get_nested_slice_ids(self):

--- a/src/experiment_prototype/interface_classes/interface_class_base.py
+++ b/src/experiment_prototype/interface_classes/interface_class_base.py
@@ -2,7 +2,7 @@
 
 """
     interface_class_base
-    ~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~
     This is the base module for all InterfaceClassBase types (iterable for an experiment given certain
     parameters). These types include the Scan class, the AveragingPeriod class, and the Sequence
     class.
@@ -183,6 +183,7 @@ class InterfaceClassBase(object):
                                               f"{bad_slices}")
             disjoint_sets[i] = sorted(list(disjoint_sets[i]))   # Convert to a list
 
+        disjoint_sets.sort(key=lambda x: x[0])
         return disjoint_sets
 
     def get_nested_slice_ids(self):


### PR DESCRIPTION
* Fixes the issue described in #449
* Docs formatted slightly incorrectly due to InterfaceClassBase refactor.
* Sort in slice_combos_sorter by first slice in each combo.