### PR TITLE
Fix for radar hanging after USRP Driver initialization on lab computer.

### DIFF
--- a/src/usrp_drivers/usrp_driver.cpp
+++ b/src/usrp_drivers/usrp_driver.cpp
@@ -159,10 +159,14 @@ void transmit(zmq::context_t &driver_c, USRP &usrp_d, const DriverOptions &drive
   start_trigger.recv(&request);
   memcpy(&initialization_time, static_cast<uhd::time_spec_t*>(request.data()), request.size());
 
+  auto driver_ready_msg = std::string("DRIVER_READY");
+  SEND_REPLY(driver_to_radar_control, driver_options.get_radctrl_to_driver_identity(),
+    driver_ready_msg);
 
-   /*This loop accepts pulse by pulse from the radar_control. It parses the samples, configures the
-    *USRP, sets up the timing, and then sends samples/timing to the USRPs.
-    */
+  /*
+  * This loop accepts pulse by pulse from the radar_control. It parses the samples, configures the
+  * USRP, sets up the timing, and then sends samples/timing to the USRPs.
+  */
   while (1)
   {
     auto more_pulses = true;
@@ -650,11 +654,6 @@ int32_t UHD_SAFE_MAIN(int32_t argc, char *argv[]) {
                             tune_delay);
   usrp_d.set_rx_center_freq(driver_packet.rxcenterfreq(), driver_options.get_receive_channels(),
                             tune_delay);
-
-
-  auto driver_ready_msg = std::string("DRIVER_READY");
-  SEND_REPLY(driver_to_radar_control, driver_options.get_radctrl_to_driver_identity(),
-    driver_ready_msg);
 
   driver_to_radar_control.close();
   std::vector<std::thread> threads;


### PR DESCRIPTION
Move the driver initialization message between the driver and radar control into the transmit thread of usrp_driver.cpp, instead of before the thread was initialized. This seems to fix what was probably a race condition, where radar_control would reply and the message would be sent after usrp_driver's main thread closes the socket and before the transmit thread re-opens it.