### PR TITLE
Scons warnings

### DIFF
--- a/src/usrp_drivers/usrp_driver.cpp
+++ b/src/usrp_drivers/usrp_driver.cpp
@@ -1,7 +1,7 @@
 /*Copyright 2016 SuperDARN*/
 #include <unistd.h>
 #include <stdint.h>
-#include <uhd/utils/thread_priority.hpp>
+#include <uhd/utils/thread.hpp>
 #include <uhd/utils/safe_main.hpp>
 #include <uhd/utils/static.hpp>
 #include <uhd/usrp/multi_usrp.hpp>
@@ -75,7 +75,7 @@ std::vector<std::vector<std::complex<float>>> make_tx_samples(
   // channel_samples_size() will get you # of channels (protobuf in c++)
   std::vector<std::vector<std::complex<float>>> samples(driver_packet.channel_samples_size());
 
-  for (uint32_t channel=0; channel<driver_packet.channel_samples_size(); channel++) {
+  for (int channel=0; channel<driver_packet.channel_samples_size(); channel++) {
     // Get the number of real samples in this particular channel (_size() is from protobuf)
     auto num_samps = driver_packet.channel_samples(channel).real_size();
     std::vector<std::complex<float>> v(num_samps);
@@ -153,10 +153,10 @@ void transmit(zmq::context_t &driver_c, USRP &usrp_d, const DriverOptions &drive
 
   zmq::message_t request;
 
-  start_trigger.recv(&request);
+  start_trigger.recv(request, zmq::recv_flags::none);
   memcpy(&ringbuffer_size, static_cast<size_t*>(request.data()), request.size());
 
-  start_trigger.recv(&request);
+  start_trigger.recv(request, zmq::recv_flags::none);
   memcpy(&initialization_time, static_cast<uhd::time_spec_t*>(request.data()), request.size());
 
   auto driver_ready_msg = std::string("DRIVER_READY");
@@ -538,7 +538,7 @@ void receive(zmq::context_t &driver_c, USRP &usrp_d, const DriverOptions &driver
 
   zmq::message_t ring_size(sizeof(ringbuffer_size));
   memcpy(ring_size.data(), &ringbuffer_size, sizeof(ringbuffer_size));
-  start_trigger.send(ring_size);
+  start_trigger.send(ring_size, zmq::send_flags::none);
 
   //This loop receives 1 pulse sequence worth of samples.
   auto first_time = true;
@@ -547,7 +547,7 @@ void receive(zmq::context_t &driver_c, USRP &usrp_d, const DriverOptions &driver
     if (first_time) {
       zmq::message_t start_time(sizeof(meta.time_spec));
       memcpy(start_time.data(), &meta.time_spec, sizeof(meta.time_spec));
-      start_trigger.send(start_time);
+      start_trigger.send(start_time, zmq::send_flags::none);
       first_time = false;
     }
     borealis_clocks.system_time = std::chrono::system_clock::now();

--- a/src/usrp_drivers/usrp_driver.cpp
+++ b/src/usrp_drivers/usrp_driver.cpp
@@ -544,6 +544,7 @@ void receive(zmq::context_t &driver_c, USRP &usrp_d, const DriverOptions &driver
   auto first_time = true;
   while (1) {
     // 3.0 is the timeout in seconds for the recv call, arbitrary number
+    rx_stream->recv(buffer_ptrs, usrp_buffer_size, meta, 3.0, true);
     if (first_time) {
       zmq::message_t start_time(sizeof(meta.time_spec));
       memcpy(start_time.data(), &meta.time_spec, sizeof(meta.time_spec));

--- a/src/usrp_drivers/usrp_driver.cpp
+++ b/src/usrp_drivers/usrp_driver.cpp
@@ -81,7 +81,7 @@ std::vector<std::vector<std::complex<float>>> make_tx_samples(
     std::vector<std::complex<float>> v(num_samps);
     // Type for smp? protobuf object, containing repeated double real and double imag
     auto smp = driver_packet.channel_samples(channel);
-    for (uint32_t smp_num = 0; smp_num < num_samps; smp_num++) {
+    for (int smp_num = 0; smp_num < num_samps; smp_num++) {
       v[smp_num] = std::complex<float>(smp.real(smp_num), smp.imag(smp_num));
     }
     samples[channel] = v;
@@ -136,7 +136,7 @@ void transmit(zmq::context_t &driver_c, USRP &usrp_d, const DriverOptions &drive
   uint32_t sqn_num = 0;
   uint32_t expected_sqn_num = 0;
 
-  uint32_t num_recv_samples;
+  uint32_t num_recv_samples = 0;
 
   size_t ringbuffer_size;
 
@@ -526,7 +526,7 @@ void receive(zmq::context_t &driver_c, USRP &usrp_d, const DriverOptions &driver
 
   uhd::rx_metadata_t meta;
 
-  uint32_t buffer_inc = 0;
+  // to remove uint32_t buffer_inc = 0;
   uint32_t timeout_count = 0;
   uint32_t overflow_count = 0;
   uint32_t overflow_oos_count = 0;
@@ -545,7 +545,7 @@ void receive(zmq::context_t &driver_c, USRP &usrp_d, const DriverOptions &driver
   auto first_time = true;
   while (1) {
     // 3.0 is the timeout in seconds for the recv call, arbitrary number
-    size_t num_rx_samples = rx_stream->recv(buffer_ptrs, usrp_buffer_size, meta, 3.0, true);
+    // to remove size_t num_rx_samples = rx_stream->recv(buffer_ptrs, usrp_buffer_size, meta, 3.0, true);
     if (first_time) {
       zmq::message_t start_time(sizeof(meta.time_spec));
       memcpy(start_time.data(), &meta.time_spec, sizeof(meta.time_spec));

--- a/src/usrp_drivers/usrp_driver.cpp
+++ b/src/usrp_drivers/usrp_driver.cpp
@@ -526,7 +526,6 @@ void receive(zmq::context_t &driver_c, USRP &usrp_d, const DriverOptions &driver
 
   uhd::rx_metadata_t meta;
 
-  // to remove uint32_t buffer_inc = 0;
   uint32_t timeout_count = 0;
   uint32_t overflow_count = 0;
   uint32_t overflow_oos_count = 0;
@@ -545,7 +544,6 @@ void receive(zmq::context_t &driver_c, USRP &usrp_d, const DriverOptions &driver
   auto first_time = true;
   while (1) {
     // 3.0 is the timeout in seconds for the recv call, arbitrary number
-    // to remove size_t num_rx_samples = rx_stream->recv(buffer_ptrs, usrp_buffer_size, meta, 3.0, true);
     if (first_time) {
       zmq::message_t start_time(sizeof(meta.time_spec));
       memcpy(start_time.data(), &meta.time_spec, sizeof(meta.time_spec));

--- a/src/usrp_drivers/utils/zmq_borealis_helpers.cpp
+++ b/src/usrp_drivers/utils/zmq_borealis_helpers.cpp
@@ -8,12 +8,11 @@ std::vector<zmq::socket_t> create_sockets(zmq::context_t &context,
                                           std::vector<std::string> identities,
                                           std::string router_address) {
 
-  //zmq::context_t context(1); // 1 is context num. Only need one per program as per examples
   std::vector<zmq::socket_t> new_sockets;
 
   for (auto &iden : identities) {
     new_sockets.push_back(zmq::socket_t(context, ZMQ_DEALER));
-    new_sockets.back().setsockopt(ZMQ_IDENTITY, iden.c_str(), iden.length());
+    new_sockets.back().set(zmq::sockopt::routing_id, iden);
     new_sockets.back().connect(router_address);
   }
 
@@ -46,7 +45,7 @@ void send_data(zmq::socket_t &socket, std::string recv_iden, std::string &data_m
 void router(zmq::context_t &context, std::string router_address)
 {
   zmq::socket_t router(context, ZMQ_ROUTER);
-  router.setsockopt(ZMQ_ROUTER_MANDATORY, 1);
+  router.set(zmq::sockopt::router_mandatory, 1);
   router.bind(router_address);
 
   while(1) {

--- a/tests/octoclock_test/octoclock_test.cpp
+++ b/tests/octoclock_test/octoclock_test.cpp
@@ -15,7 +15,7 @@
 #include <boost/thread/thread.hpp>
 
 #include <uhd/utils/safe_main.hpp>
-#include <uhd/utils/thread_priority.hpp>
+#include <uhd/utils/thread.hpp>
 #include <uhd/usrp_clock/multi_usrp_clock.hpp>
 #include "src/usrp_drivers/utils/shared_macros.hpp"
 

--- a/tests/rx_tx_delay_test/rx_tx_delay_test.cpp
+++ b/tests/rx_tx_delay_test/rx_tx_delay_test.cpp
@@ -508,7 +508,7 @@ void do_rx(
 		// double-check the timing of the event //
 		double usrp_time_now = usrp->get_time_now(rx_channel).get_real_secs();
 		double seconds_in_future = (event_time - usrp_time_now);
-    double timeout = seconds_in_future;
+		double timeout = seconds_in_future;
 		double packet_timeout = 0;
 
 		size_t num_acc_samps = 0; // number of accumulated samples
@@ -524,8 +524,8 @@ void do_rx(
 		usrp->issue_stream_cmd(stream_cmd, rx_channel);
 
 		bool do_once = true;
-		double tdiff = 0;
-		double actual_event_time = 0;
+		// to remove double tdiff = 0;
+		// to remove double actual_event_time = 0;
 		size_t reps = 0;
 
 		while(!boost::this_thread::interruption_requested())
@@ -535,8 +535,8 @@ void do_rx(
 			num_acc_samps = 0;
 
 			do_once = true;
-			tdiff = 0;
-			actual_event_time = 0;
+			// to remove tdiff = 0;
+			// to remove actual_event_time = 0;
 			reps = 0;
 
 			while(!boost::this_thread::interruption_requested() && num_acc_samps < burst_length)
@@ -593,7 +593,7 @@ void do_rx(
 				if(do_once)
 				{
 					do_once = false;
-					actual_event_time = md.time_spec.get_real_secs();
+					// to remove actual_event_time = md.time_spec.get_real_secs();
 				}
 			}
 
@@ -692,7 +692,7 @@ void do_tx(
 		double fs = rate;
 
 		// burst duration //
-		double duration = ((double)burst_length) * fs;
+		// to remove double duration = ((double)burst_length) * fs;
 
 		// set t0 //
 		double event_time = start_time;
@@ -715,14 +715,14 @@ void do_tx(
 		size_t to_tx = 0; // number of samples to transmit
 
 		uhd::async_metadata_t async_md;
-		bool got_async_burst_ack = false;
+		// to remove bool got_async_burst_ack = false;
 
-		double actual_event_time = 0;
+		// to remove double actual_event_time = 0;
 
 		while(!boost::this_thread::interruption_requested())
 		{
 			num_acc_samps = 0;
-			actual_event_time = 0;
+			// to remove actual_event_time = 0;
 
 			while(!boost::this_thread::interruption_requested() && num_acc_samps < burst_length)
 			{
@@ -751,7 +751,7 @@ void do_tx(
 			md.end_of_burst = true;
 			tx_stream->send("", 0, md);
 
-			got_async_burst_ack = false;
+			// to remove got_async_burst_ack = false;
 			bool error_in_burst = false;
 			size_t last_error_code = uhd::async_metadata_t::EVENT_CODE_BURST_ACK;
 
@@ -760,8 +760,8 @@ void do_tx(
 			{
 				if(async_md.event_code == uhd::async_metadata_t::EVENT_CODE_BURST_ACK)
 				{
-					actual_event_time =  async_md.time_spec.get_real_secs() - duration;
-					got_async_burst_ack = true;
+					// to remove actual_event_time =  async_md.time_spec.get_real_secs() - duration;
+					// to remove got_async_burst_ack = true;
 					break;
 				}
 				else if(!error_in_burst)

--- a/tests/rx_tx_delay_test/rx_tx_delay_test.cpp
+++ b/tests/rx_tx_delay_test/rx_tx_delay_test.cpp
@@ -524,8 +524,6 @@ void do_rx(
 		usrp->issue_stream_cmd(stream_cmd, rx_channel);
 
 		bool do_once = true;
-		// to remove double tdiff = 0;
-		// to remove double actual_event_time = 0;
 		size_t reps = 0;
 
 		while(!boost::this_thread::interruption_requested())
@@ -535,8 +533,6 @@ void do_rx(
 			num_acc_samps = 0;
 
 			do_once = true;
-			// to remove tdiff = 0;
-			// to remove actual_event_time = 0;
 			reps = 0;
 
 			while(!boost::this_thread::interruption_requested() && num_acc_samps < burst_length)
@@ -593,7 +589,6 @@ void do_rx(
 				if(do_once)
 				{
 					do_once = false;
-					// to remove actual_event_time = md.time_spec.get_real_secs();
 				}
 			}
 
@@ -691,9 +686,6 @@ void do_tx(
 		// get the sample rate //
 		double fs = rate;
 
-		// burst duration //
-		// to remove double duration = ((double)burst_length) * fs;
-
 		// set t0 //
 		double event_time = start_time;
 
@@ -715,14 +707,10 @@ void do_tx(
 		size_t to_tx = 0; // number of samples to transmit
 
 		uhd::async_metadata_t async_md;
-		// to remove bool got_async_burst_ack = false;
-
-		// to remove double actual_event_time = 0;
 
 		while(!boost::this_thread::interruption_requested())
 		{
 			num_acc_samps = 0;
-			// to remove actual_event_time = 0;
 
 			while(!boost::this_thread::interruption_requested() && num_acc_samps < burst_length)
 			{
@@ -751,7 +739,6 @@ void do_tx(
 			md.end_of_burst = true;
 			tx_stream->send("", 0, md);
 
-			// to remove got_async_burst_ack = false;
 			bool error_in_burst = false;
 			size_t last_error_code = uhd::async_metadata_t::EVENT_CODE_BURST_ACK;
 
@@ -760,8 +747,6 @@ void do_tx(
 			{
 				if(async_md.event_code == uhd::async_metadata_t::EVENT_CODE_BURST_ACK)
 				{
-					// to remove actual_event_time =  async_md.time_spec.get_real_secs() - duration;
-					// to remove got_async_burst_ack = true;
 					break;
 				}
 				else if(!error_in_burst)

--- a/tests/rx_tx_delay_test/rx_tx_delay_test.cpp
+++ b/tests/rx_tx_delay_test/rx_tx_delay_test.cpp
@@ -17,7 +17,7 @@
 
 // part of this file was created by Max Scharrenbroich, use it as you like...
 
-#include <uhd/utils/thread_priority.hpp>
+#include <uhd/utils/thread.hpp>
 #include <uhd/utils/safe_main.hpp>
 #include <uhd/utils/static.hpp>
 #include <uhd/usrp/multi_usrp.hpp>

--- a/tests/test_rx_tx/test_rx_tx.cpp
+++ b/tests/test_rx_tx/test_rx_tx.cpp
@@ -104,9 +104,9 @@ void recv(uhd::usrp::multi_usrp::sptr &usrp_d, std::vector<size_t> &rx_chans) {
   rx_stream_cmd.num_samps = 0;
   rx_stream_cmd.time_spec = usrp_d->get_time_now() + uhd::time_spec_t(DELAY);
 
-  auto stream_start = std::chrono::steady_clock::now();
+  // to remove: auto stream_start = std::chrono::steady_clock::now();
   rx_stream->issue_stream_cmd(rx_stream_cmd);
-  auto stream_end = std::chrono::steady_clock::now();
+  // to remove: auto stream_end = std::chrono::steady_clock::now();
 
   uhd::rx_metadata_t meta;
 
@@ -254,7 +254,7 @@ void tx(uhd::usrp::multi_usrp::sptr &usrp_d, std::vector<size_t> &tx_chans) {
     };
 
 
-    for(int i=0; i<time_per_pulse.size(); i++){
+    for(uint32_t i=0; i<time_per_pulse.size(); i++){
       send(time_per_pulse[i]);
     }
 
@@ -340,7 +340,7 @@ int UHD_SAFE_MAIN(int argc, char *argv[]) {
   
   usrp_d->set_time_now(tt_sc.count());
 
-  for (int i=0; i<usrp_d->get_num_mboards(); i++){
+  for (uint32_t i=0; i<usrp_d->get_num_mboards(); i++){
     usrp_d->set_gpio_attr("RXA", "CTRL", 0xFFFF, 0b11111111, i);
     usrp_d->set_gpio_attr("RXA", "DDR", 0xFFFF, 0b11111111, i);
 
@@ -423,6 +423,8 @@ int UHD_SAFE_MAIN(int argc, char *argv[]) {
       	// Error
       	std::cout << "Invalid testing mode selected." << std:: endl;
       	return 0;
-      }      
+      }    
+
+  return 0;
 }
 

--- a/tests/test_rx_tx/test_rx_tx.cpp
+++ b/tests/test_rx_tx/test_rx_tx.cpp
@@ -104,9 +104,7 @@ void recv(uhd::usrp::multi_usrp::sptr &usrp_d, std::vector<size_t> &rx_chans) {
   rx_stream_cmd.num_samps = 0;
   rx_stream_cmd.time_spec = usrp_d->get_time_now() + uhd::time_spec_t(DELAY);
 
-  // to remove: auto stream_start = std::chrono::steady_clock::now();
   rx_stream->issue_stream_cmd(rx_stream_cmd);
-  // to remove: auto stream_end = std::chrono::steady_clock::now();
 
   uhd::rx_metadata_t meta;
 


### PR DESCRIPTION
Removed unused variables, updated deprecated zmq methods, and updated header include names.

Code now compiles in both release and debug mode without throwing any warnings (on the lab computer at least).