### PR TITLE
Rich Printer Crashes

### DIFF
--- a/tests/log_printer/json_to_rich_logs.py
+++ b/tests/log_printer/json_to_rich_logs.py
@@ -66,6 +66,11 @@ if __name__ == "__main__":
                         log.warning(msg, **current_entry)
                     elif level == "critical":
                         log.critical(msg, **current_entry)
+                    elif level == "error":
+                        log.error(
+                            "json_to_rich_logs.py is currently unable to "
+                            "properly build tracebacks on errors, skipping"
+                        )
                     else:
                         raise ValueError(f"Unknown log level: {level}")
             elif event == "start_array":


### PR DESCRIPTION
When an error was in listed in the log file, the rich printer would crash as it was not set up to handle errors. This change just allows it to keep going and print a warning to screen that parsing an error report was skipped.