### PR TITLE
Cupy mem allocation

### DIFF
--- a/src/experiment_prototype/interface_classes/averaging_periods.py
+++ b/src/experiment_prototype/interface_classes/averaging_periods.py
@@ -269,8 +269,8 @@ class AveragingPeriod(InterfaceClassBase):
                         mask[
                             np.argwhere(
                                 np.logical_and(
-                                    shifted_cfs_khz >= ctr_freq - 50,
-                                    shifted_cfs_khz <= ctr_freq + 50,
+                                    shifted_cfs_khz >= np.floor(ctr_freq - 50),
+                                    shifted_cfs_khz <= np.ceil(ctr_freq + 50),
                                 )
                             )
                         ] = False

--- a/src/rx_signal_processing.py
+++ b/src/rx_signal_processing.py
@@ -154,7 +154,7 @@ def sequence_worker(options, ringbuffer):
         else:
             sender_iden = options.dsp_to_dw_identity + str(rx_params.sequence_num)
             recipient_iden = options.dw_to_dsp_identity
-        log.info(
+        log.debug(
             "socket identities:",
             sender=sender_iden,
             recip=recipient_iden,
@@ -456,7 +456,7 @@ def sequence_worker(options, ringbuffer):
                 time.perf_counter() - mark_timer
             ) * 1e3
 
-        log.info(
+        log.debug(
             "Sending processed data",
             recieve=recipient_iden,
             sender=processed_socket.get(zmq.IDENTITY),

--- a/src/rx_signal_processing.py
+++ b/src/rx_signal_processing.py
@@ -23,6 +23,8 @@ import zmq
 
 try:
     import cupy as xp
+
+    xp.cuda.set_allocator(None)
 except ImportError:
     cupy_available = False
     import numpy as xp

--- a/src/utils/signals.py
+++ b/src/utils/signals.py
@@ -286,7 +286,9 @@ class DSP:
 
         # [num_slices, num_taps]
         # [num_antennas, num_output_samples, num_taps]
-        filtered = xp.einsum("ij,klj->ikl", bp_filters, input_samples)
+        filtered = xp.einsum(
+            "ij,klj->ikl", bp_filters, input_samples, optimize="greedy"
+        )
 
         # Apply the phase correction for the Frerking method.
         ph = xp.arange(filtered.shape[-1], dtype=np.float32)[xp.newaxis, :]


### PR DESCRIPTION
Cupy's memory allocation methods were crashing the radar for experiments that had very high memory requests as it would try to allocate more memory than was available on the GPU. These changes are a step towards better memory management on the GPU. They ensure that the memory used after a sequence has been processed is freed before the next sequence starts. Previously cupy was allocating twice the amount of memory than was required. 

Further improvements can likely be made to the GPU memory usage, but this should help prevent experiments from overloading a GPU. Unfortunately this does add more time to the DSP processing. On the lab computer DSP took on average 10ms longer each sequence but the double memory allocation was stopped. See #260 for more cupy memory management ideas that could be tackled in the future.