### PR TITLE
Bugfix/scan interface cfs

### DIFF
--- a/src/data_write.py
+++ b/src/data_write.py
@@ -1421,12 +1421,22 @@ class DataWrite(object):
                 ]
                 parameters.blanked_samples = np.array(sqn_meta.blanks, dtype=np.uint32)
                 parameters.borealis_git_hash = self.git_hash.decode("utf-8")
-                parameters.cfs_freqs = np.array(aveperiod_meta.cfs_freqs)
-                parameters.cfs_noise = np.array(aveperiod_meta.cfs_noise)
-                parameters.cfs_range = np.array(aveperiod_meta.cfs_range)
-                parameters.cfs_masks = np.array(
-                    aveperiod_meta.cfs_masks[np.uint32(rx_channel.slice_id)]
-                )
+
+                if np.uint32(rx_channel.slice_id) in aveperiod_meta.cfs_slice_ids:
+                    parameters.cfs_freqs = np.array(aveperiod_meta.cfs_freqs)
+                    parameters.cfs_noise = np.array(aveperiod_meta.cfs_noise)
+                    parameters.cfs_range = np.array(
+                        aveperiod_meta.cfs_range[np.uint32(rx_channel.slice_id)]
+                    )
+                    parameters.cfs_masks = np.array(
+                        aveperiod_meta.cfs_masks[np.uint32(rx_channel.slice_id)]
+                    )
+                else:
+                    parameters.cfs_freqs = np.array([])
+                    parameters.cfs_noise = np.array([])
+                    parameters.cfs_range = np.array([])
+                    parameters.cfs_masks = np.array([])
+
                 parameters.data_normalization_factor = (
                     aveperiod_meta.data_normalization_factor
                 )

--- a/src/experiment_prototype/interface_classes/averaging_periods.py
+++ b/src/experiment_prototype/interface_classes/averaging_periods.py
@@ -353,16 +353,19 @@ class AveragingPeriod(InterfaceClassBase):
         Builds an empty rx only pulse sequence to collect clear frequency search data
         """
         pulse_length = 100  # us
-        num_ranges = int(round((self.slice_dict[0].cfs_duration * 1000) / pulse_length))
+        slice_id = self.cfs_slice_ids[0]  # get first cfs slice id
+        num_ranges = int(
+            round((self.slice_dict[slice_id].cfs_duration * 1000) / pulse_length)
+        )
         # calculate number of ranges (cfs_duration is in ms)
 
         # Create a CFS slice for the pulse
         default_slice = {
-            "cpid": self.slice_dict[0].cpid,
+            "cpid": self.slice_dict[slice_id].cpid,
             "slice_id": 0,
-            "transition_bandwidth": self.slice_dict[0].transition_bandwidth,
-            "rx_bandwidth": self.slice_dict[0].rx_bandwidth,
-            "tx_bandwidth": self.slice_dict[0].tx_bandwidth,
+            "transition_bandwidth": self.slice_dict[slice_id].transition_bandwidth,
+            "rx_bandwidth": self.slice_dict[slice_id].rx_bandwidth,
+            "tx_bandwidth": self.slice_dict[slice_id].tx_bandwidth,
             "txctrfreq": self.txctrfreq,
             "rxctrfreq": self.rxctrfreq,
             "rxonly": True,
@@ -375,7 +378,7 @@ class AveragingPeriod(InterfaceClassBase):
             "beam_angle": [0.0],
             "rx_beam_order": [0],
             "freq": None,  # kHz
-            "decimation_scheme": self.slice_dict[0].cfs_scheme,
+            "decimation_scheme": self.slice_dict[slice_id].cfs_scheme,
         }
 
         cfs_slices = {}

--- a/src/radar_control.py
+++ b/src/radar_control.py
@@ -61,7 +61,7 @@ class RadctrlParameters:
     cfs_scan_flag: bool = False
     cfs_freq: list = field(default_factory=list)
     cfs_mags: list = field(default_factory=list)
-    cfs_range: list = field(default_factory=list)
+    cfs_range: list = field(default_factory=dict)
     cfs_masks: list = field(default_factory=dict)
     scan_flag: bool = False
     dsp_cfs_identity: str = ""
@@ -470,6 +470,7 @@ def create_dw_message(radctrl_params):
     message.cfs_noise = radctrl_params.cfs_mags
     message.cfs_range = radctrl_params.cfs_range
     message.cfs_masks = radctrl_params.cfs_masks
+    message.cfs_slice_ids = radctrl_params.aveperiod.cfs_slice_ids
 
     for sequence_index, sequence in enumerate(radctrl_params.aveperiod.sequences):
         sequence_add = messages.Sequence()
@@ -1034,11 +1035,10 @@ def main():
                         ave_params.cfs_mags = [
                             mag.cfs_data for mag in freq_spectrum.output_datasets
                         ]
-                        ave_params.cfs_range = [
-                            obj.cfs_range
-                            for sqn in aveperiod.cfs_sequences
-                            for obj in sqn.slice_dict.values()
-                        ]
+                        for ind in range(len(aveperiod.cfs_slice_ids)):
+                            ave_params.cfs_range[aveperiod.cfs_slice_ids[ind]] = (
+                                aveperiod.cfs_range[ind]
+                            )
                     # End CFS block
 
                     for sequence_index, sequence in enumerate(aveperiod.sequences):

--- a/src/utils/message_formats.py
+++ b/src/utils/message_formats.py
@@ -251,6 +251,7 @@ class AveperiodMetadataMessage:
     cfs_noise: list = field(default_factory=list)
     cfs_range: list = field(default_factory=list)
     cfs_masks: list = field(default_factory=list)
+    cfs_slice_ids: list = field(default_factory=list)
 
     def add_sequence(self, sequence: dict):
         """Add a sequence dict to the message."""


### PR DESCRIPTION
Found an issue with building the cfs sequence when `SCAN` or `AVEPERIOD` interfacing was used between slices. Also identified an issue with non-CFS experiments or experiments with non-CFS slices failing to write data to file. Added some additional logic to the data write parameter parsing to manage these cases and implemented dictionaries to reference the cfs_range based on the slice_id.