### PR TITLE
User control params for CFS

### DIFF
--- a/docs/source/new_experiments.rst
+++ b/docs/source/new_experiments.rst
@@ -162,7 +162,7 @@ The following parameters can be set for a CFS slice:
      - Sets a minimum amount of time during which CFS will not change the frequency of a CFS slice
        after it has been set
    * - ``cfs_pwr_threshold``
-     - ``None``
+     - ``None`` (dB)
      - Sets a threshold power difference that a CFS scan must exceed before a frequency is switched.
        If another frequency is lower in power than the current frequency was when set by the
        threshold or if the current frequency power has increased by more than the threshold, then

--- a/docs/source/new_experiments.rst
+++ b/docs/source/new_experiments.rst
@@ -162,11 +162,12 @@ The following parameters can be set for a CFS slice:
      - Sets a minimum amount of time during which CFS will not change the frequency of a CFS slice
        after it has been set
    * - ``cfs_pwr_threshold``
-     - -20 dB
+     - None
      - Sets a threshold power difference that a CFS scan must exceed before a frequency is switched.
        If another frequency is lower in power than the current frequency was when set by the
        threshold or if the current frequency power has increased by more than the threshold, then
-       CFS will set a new frequency for the CFS slices.
+       CFS will set a new frequency for the CFS slices. When set the threshold value must be greater
+       than zero.
    * - ``cfs_fft_n``
      - 512
      - Sets the number of samples used in the FFT during CFS processing. Determines the frequency

--- a/docs/source/new_experiments.rst
+++ b/docs/source/new_experiments.rst
@@ -157,6 +157,20 @@ The following parameters can be set for a CFS slice:
      - ``create_default_cfs_scheme()``
      - Decimation scheme used in analyzing the CFS data. The default scheme is designed for bands
        of 300kHz or less
+   * - ``cfs_stable_time``
+     - 0 s
+     - Sets a minimum amount of time during which CFS will not change the frequency of a CFS slice
+       after it has been set
+   * - ``cfs_pwr_threshold``
+     - -20 dB
+     - Sets a threshold power difference that a CFS scan must exceed before a frequency is switched.
+       If another frequency is lower in power than the current frequency was when set by the
+       threshold or if the current frequency power has increased by more than the threshold, then
+       CFS will set a new frequency for the CFS slices.
+   * - ``cfs_fft_n``
+     - 512
+     - Sets the number of samples used in the FFT during CFS processing. Determines the frequency
+       resolution of the CFS, where the resolution is ``res = (rx_rate / total decimation rate) / N``
 
 When a CFS slice is to be run during an averaging period, the first sequence of the averaging period
 is used to listen for the length of time specified by ``cfs_duration``. The data from this measurement

--- a/src/data_write.py
+++ b/src/data_write.py
@@ -1421,12 +1421,22 @@ class DataWrite(object):
                 ]
                 parameters.blanked_samples = np.array(sqn_meta.blanks, dtype=np.uint32)
                 parameters.borealis_git_hash = self.git_hash.decode("utf-8")
-                parameters.cfs_freqs = np.array(aveperiod_meta.cfs_freqs)
-                parameters.cfs_noise = np.array(aveperiod_meta.cfs_noise)
-                parameters.cfs_range = np.array(aveperiod_meta.cfs_range)
-                parameters.cfs_masks = np.array(
-                    aveperiod_meta.cfs_masks[np.uint32(rx_channel.slice_id)]
-                )
+
+                if np.uint32(rx_channel.slice_id) in aveperiod_meta.cfs_slice_ids:
+                    parameters.cfs_freqs = np.array(aveperiod_meta.cfs_freqs)
+                    parameters.cfs_noise = np.array(aveperiod_meta.cfs_noise)
+                    parameters.cfs_range = np.array(
+                        aveperiod_meta.cfs_range[np.uint32(rx_channel.slice_id)]
+                    )
+                    parameters.cfs_masks = np.array(
+                        aveperiod_meta.cfs_masks[np.uint32(rx_channel.slice_id)]
+                    )
+                else:
+                    parameters.cfs_freqs = np.array([])
+                    parameters.cfs_noise = np.array([])
+                    parameters.cfs_range = np.array([])
+                    parameters.cfs_masks = np.array([])
+
                 parameters.data_normalization_factor = (
                     aveperiod_meta.data_normalization_factor
                 )

--- a/src/experiment_prototype/experiment_slice.py
+++ b/src/experiment_prototype/experiment_slice.py
@@ -198,6 +198,20 @@ class ExperimentSlice:
     cfs_scheme *defaults*
         Decimation scheme to be used in analyzing data collected during a clear frequency search when
         determining transmit frequencies for CFS experiment slices
+    cfs_stable_time *defaults*
+        Amount of time in seconds clear frequency search will not change the slice frequencies for.
+        Ensures a minimum stable time, but does not force a change in frequency once the stable time
+        has elapsed.
+    cfs_pwr_threshold *defaults*
+         Difference in power (in dB) that clear frequency search must see in the measured frequencies
+         before it changes the cfs slice frequencies. This can be trigered either when another
+         frequency in the cfs range is found to have a lower power than the currently set frequency, or
+         when the currently set frequency has increased in power by the threshold value since it was
+         selected as an operating frequency.
+    cfs_fft_n *defaults*
+        Sets the number of elements used in the fft when processing clear frequency search results.
+        Determines the frequency resolution of the processing following the formula;
+        frequency resolution = (rx rate / total decimation rate) / cfs fft n value
     comment *defaults*
         a comment string that will be placed in the borealis files describing the slice. Defaults to
         empty string.
@@ -364,7 +378,7 @@ class ExperimentSlice:
     cfs_scheme: DecimationScheme = Field(default_factory=create_default_cfs_scheme)
     cfs_stable_time: Optional[conint(ge=0, strict=True)] = 0  # seconds
     cfs_pwr_threshold: Optional[confloat(strict=True)] = -20.0  # dB
-    cfs_res_min: Optional[conint(ge=0, strict=True)] = 300  # kHz
+    cfs_fft_n: Optional[conint(ge=0, strict=True)] = 512
     decimation_scheme: DecimationScheme = Field(default_factory=create_default_scheme)
 
     acf: Optional[StrictBool] = False

--- a/src/experiment_prototype/experiment_slice.py
+++ b/src/experiment_prototype/experiment_slice.py
@@ -362,6 +362,7 @@ class ExperimentSlice:
     cfs_flag: StrictBool = Field(init=False)
     cfs_duration: Optional[conint(ge=0, strict=True)] = 90  # ms
     cfs_scheme: DecimationScheme = Field(default_factory=create_default_cfs_scheme)
+    cfs_min_stable_time: Optional[conint(ge=0, strict=True)] = 900  # seconds
     decimation_scheme: DecimationScheme = Field(default_factory=create_default_scheme)
 
     acf: Optional[StrictBool] = False

--- a/src/experiment_prototype/experiment_slice.py
+++ b/src/experiment_prototype/experiment_slice.py
@@ -363,7 +363,7 @@ class ExperimentSlice:
     cfs_duration: Optional[conint(ge=0, strict=True)] = 90  # ms
     cfs_scheme: DecimationScheme = Field(default_factory=create_default_cfs_scheme)
     cfs_stable_time: Optional[conint(ge=0, strict=True)] = 0  # seconds
-    cfs_pwr_threshold: Optional[confloat(ge=0, strict=True)] = 1.0  # dB
+    cfs_pwr_threshold: Optional[confloat(strict=True)] = -20.0  # dB
     cfs_res_min: Optional[conint(ge=0, strict=True)] = 300  # kHz
     decimation_scheme: DecimationScheme = Field(default_factory=create_default_scheme)
 

--- a/src/experiment_prototype/experiment_slice.py
+++ b/src/experiment_prototype/experiment_slice.py
@@ -362,7 +362,9 @@ class ExperimentSlice:
     cfs_flag: StrictBool = Field(init=False)
     cfs_duration: Optional[conint(ge=0, strict=True)] = 90  # ms
     cfs_scheme: DecimationScheme = Field(default_factory=create_default_cfs_scheme)
-    cfs_stable_time: Optional[conint(ge=0, strict=True)] = 900  # seconds
+    cfs_stable_time: Optional[conint(ge=0, strict=True)] = 0  # seconds
+    cfs_pwr_threshold: Optional[confloat(ge=0, strict=True)] = 1.0  # dB
+    cfs_res_min: Optional[conint(ge=0, strict=True)] = 300  # kHz
     decimation_scheme: DecimationScheme = Field(default_factory=create_default_scheme)
 
     acf: Optional[StrictBool] = False

--- a/src/experiment_prototype/experiment_slice.py
+++ b/src/experiment_prototype/experiment_slice.py
@@ -377,7 +377,7 @@ class ExperimentSlice:
     cfs_duration: Optional[conint(ge=0, strict=True)] = 90  # ms
     cfs_scheme: DecimationScheme = Field(default_factory=create_default_cfs_scheme)
     cfs_stable_time: Optional[conint(ge=0, strict=True)] = 0  # seconds
-    cfs_pwr_threshold: Optional[confloat(strict=True)] = -20.0  # dB
+    cfs_pwr_threshold: Optional[confloat(ge=0)] = None  # dB
     cfs_fft_n: Optional[conint(ge=0, strict=True)] = 512
     decimation_scheme: DecimationScheme = Field(default_factory=create_default_scheme)
 

--- a/src/experiment_prototype/experiment_slice.py
+++ b/src/experiment_prototype/experiment_slice.py
@@ -362,7 +362,7 @@ class ExperimentSlice:
     cfs_flag: StrictBool = Field(init=False)
     cfs_duration: Optional[conint(ge=0, strict=True)] = 90  # ms
     cfs_scheme: DecimationScheme = Field(default_factory=create_default_cfs_scheme)
-    cfs_min_stable_time: Optional[conint(ge=0, strict=True)] = 900  # seconds
+    cfs_stable_time: Optional[conint(ge=0, strict=True)] = 900  # seconds
     decimation_scheme: DecimationScheme = Field(default_factory=create_default_scheme)
 
     acf: Optional[StrictBool] = False

--- a/src/experiment_prototype/interface_classes/averaging_periods.py
+++ b/src/experiment_prototype/interface_classes/averaging_periods.py
@@ -104,7 +104,7 @@ class AveragingPeriod(InterfaceClassBase):
         self.cfs_slice_ids = []
         self.cfs_stable_time = 0
         self.cfs_pwr_threshold = 0
-        self.cfs_res_min = 0
+        self.cfs_fft_n = 0
         # there may be multiple slices in this averaging period at different frequencies so
         # we may have to search multiple ranges.
         self.cfs_range = []
@@ -112,7 +112,7 @@ class AveragingPeriod(InterfaceClassBase):
             if self.slice_dict[slice_id].cfs_flag:
                 self.cfs_stable_time = self.slice_dict[slice_id].cfs_stable_time
                 self.cfs_pwr_threshold = self.slice_dict[slice_id].cfs_pwr_threshold
-                self.cfs_res_min = self.slice_dict[slice_id].cfs_res_min
+                self.cfs_fft_n = self.slice_dict[slice_id].cfs_fft_n
                 self.cfs_flag = True
                 self.cfs_slice_ids.append(slice_id)
                 self.cfs_range.append(self.slice_dict[slice_id].cfs_range)
@@ -169,10 +169,10 @@ class AveragingPeriod(InterfaceClassBase):
                     " interfaced and do not have the same cfs_power_threshold"
                 )
                 raise ExperimentException(errmsg)
-            if self.slice_dict[slice_id].cfs_res_min != self.cfs_res_min:
+            if self.slice_dict[slice_id].cfs_fft_n != self.cfs_fft_n:
                 errmsg = (
                     f"Slices {self.slice_ids[0]} and {slice_id} are SEQUENCE or CONCURRENT"
-                    " interfaced and do not have the same cfs_res_min"
+                    " interfaced and do not have the same cfs_fft_n"
                 )
                 raise ExperimentException(errmsg)
             if self.slice_dict[slice_id].cfs_stable_time != self.cfs_stable_time:

--- a/src/experiment_prototype/interface_classes/averaging_periods.py
+++ b/src/experiment_prototype/interface_classes/averaging_periods.py
@@ -102,11 +102,13 @@ class AveragingPeriod(InterfaceClassBase):
         self.cfs_flag = False
         self.cfs_sequence = None
         self.cfs_slice_ids = []
+        self.cfs_min_stable_time = 0
         # there may be multiple slices in this averaging period at different frequencies so
         # we may have to search multiple ranges.
         self.cfs_range = []
         for slice_id in self.slice_ids:
             if self.slice_dict[slice_id].cfs_flag:
+                self.cfs_min_stable_time = self.slice_dict[slice_id].cfs_min_stable_time
                 self.cfs_flag = True
                 self.cfs_slice_ids.append(slice_id)
                 self.cfs_range.append(self.slice_dict[slice_id].cfs_range)

--- a/src/experiment_prototype/interface_classes/averaging_periods.py
+++ b/src/experiment_prototype/interface_classes/averaging_periods.py
@@ -353,16 +353,19 @@ class AveragingPeriod(InterfaceClassBase):
         Builds an empty rx only pulse sequence to collect clear frequency search data
         """
         pulse_length = 100  # us
-        num_ranges = int(round((self.slice_dict[0].cfs_duration * 1000) / pulse_length))
+        slice_id = self.cfs_slice_ids[0]  # get first cfs slice id
+        num_ranges = int(
+            round((self.slice_dict[slice_id].cfs_duration * 1000) / pulse_length)
+        )
         # calculate number of ranges (cfs_duration is in ms)
 
         # Create a CFS slice for the pulse
         default_slice = {
-            "cpid": self.slice_dict[0].cpid,
+            "cpid": self.slice_dict[slice_id].cpid,
             "slice_id": 0,
-            "transition_bandwidth": self.slice_dict[0].transition_bandwidth,
-            "rx_bandwidth": self.slice_dict[0].rx_bandwidth,
-            "tx_bandwidth": self.slice_dict[0].tx_bandwidth,
+            "transition_bandwidth": self.slice_dict[slice_id].transition_bandwidth,
+            "rx_bandwidth": self.slice_dict[slice_id].rx_bandwidth,
+            "tx_bandwidth": self.slice_dict[slice_id].tx_bandwidth,
             "txctrfreq": self.txctrfreq,
             "rxctrfreq": self.rxctrfreq,
             "rxonly": True,
@@ -375,7 +378,7 @@ class AveragingPeriod(InterfaceClassBase):
             "beam_angle": [0.0],
             "rx_beam_order": [0],
             "freq": None,  # kHz
-            "decimation_scheme": self.slice_dict[0].cfs_scheme,
+            "decimation_scheme": self.slice_dict[slice_id].cfs_scheme,
         }
 
         cfs_slices = {}

--- a/src/experiment_prototype/interface_classes/averaging_periods.py
+++ b/src/experiment_prototype/interface_classes/averaging_periods.py
@@ -102,13 +102,13 @@ class AveragingPeriod(InterfaceClassBase):
         self.cfs_flag = False
         self.cfs_sequence = None
         self.cfs_slice_ids = []
-        self.cfs_min_stable_time = 0
+        self.cfs_stable_time = 0
         # there may be multiple slices in this averaging period at different frequencies so
         # we may have to search multiple ranges.
         self.cfs_range = []
         for slice_id in self.slice_ids:
             if self.slice_dict[slice_id].cfs_flag:
-                self.cfs_min_stable_time = self.slice_dict[slice_id].cfs_min_stable_time
+                self.cfs_stable_time = self.slice_dict[slice_id].cfs_stable_time
                 self.cfs_flag = True
                 self.cfs_slice_ids.append(slice_id)
                 self.cfs_range.append(self.slice_dict[slice_id].cfs_range)

--- a/src/radar_control.py
+++ b/src/radar_control.py
@@ -47,28 +47,20 @@ class CFSParameters:
 
     def check_update_freq(self, cfs_spectrum, cfs_slices, threshold):
         cfs_data = [dset.cfs_data for dset in cfs_spectrum.output_datasets]
-        log.info("Doing a check")
         for i, slice_id in enumerate(cfs_slices):
             if any(
                 cfs_data[i][self.cfs_masks[slice_id]]
                 <= self.last_cfs_power[slice_id][1] - threshold
             ):
                 self.set_new_freq = True
-                log.info(
-                    "Found power lower then",
-                    threshold=self.last_cfs_power[slice_id][1] - threshold,
-                    checked_len=len(cfs_data[i][self.cfs_masks[slice_id]]),
-                    slice=slice_id,
-                )
-            idx = (np.abs(self.cfs_freq - self.last_cfs_power[slice_id][0])).argmin()
+            shifted_frequency = self.last_cfs_power[slice_id][0] - int(
+                sum(self.cfs_range[slice_id]) / 2
+            )
+            idx = (
+                np.abs(np.asarray(self.cfs_freq) - shifted_frequency * 1000)
+            ).argmin()
             if cfs_data[i][idx] > self.last_cfs_power[slice_id][1] + threshold:
                 self.set_new_freq = True
-                log.info(
-                    "Found current freq is too high",
-                    lim=self.last_cfs_power[slice_id][1] + threshold,
-                    current=cfs_data[i][idx],
-                    slice=slice_id,
-                )
 
 
 @dataclass

--- a/src/radar_control.py
+++ b/src/radar_control.py
@@ -37,6 +37,10 @@ TIME_PROFILE = False
 
 @dataclass
 class CFSParameters:
+    """
+    Parameters used to track clear frequency search
+    """
+
     cfs_freq: list = field(default_factory=list)
     cfs_mags: list = field(default_factory=list)
     cfs_range: list = field(default_factory=dict)
@@ -46,10 +50,21 @@ class CFSParameters:
     set_new_freq: bool = True
 
     def check_update_freq(self, cfs_spectrum, cfs_slices, threshold):
+        """
+        Checks if any scanned frequencies have power levels that
+        exceed the current power of each cfs slice based on a threshold
+
+        :params cfs_spectrum:   Results of the CFS analysis
+        :type   cfs_spectrum:   dataclass
+        :params cfs_slices:     Slice ids of each cfs slice to be checked
+        :type   cfs_slices:     list
+        :params threshold:      Power threshold (dB) used in check
+        :type   threshold:      float
+        """
         cfs_data = [dset.cfs_data for dset in cfs_spectrum.output_datasets]
         for i, slice_id in enumerate(cfs_slices):
             if any(
-                cfs_data[i][self.cfs_masks[slice_id]]
+                np.asarray(cfs_data[i][self.cfs_masks[slice_id]])
                 <= self.last_cfs_power[slice_id][1] - threshold
             ):
                 self.set_new_freq = True

--- a/src/radar_control.py
+++ b/src/radar_control.py
@@ -43,10 +43,10 @@ class CFSParameters:
 
     cfs_freq: list = field(default_factory=list)
     cfs_mags: list = field(default_factory=list)
-    cfs_range: list = field(default_factory=dict)
-    cfs_masks: list = field(default_factory=dict)
+    cfs_range: dict = field(default_factory=dict)
+    cfs_masks: dict = field(default_factory=dict)
     last_cfs_set_time: int = 0
-    last_cfs_power: list = field(default_factory=dict)
+    last_cfs_power: dict = field(default_factory=dict)
     set_new_freq: bool = True
 
     def check_update_freq(self, cfs_spectrum, cfs_slices, threshold):
@@ -55,7 +55,7 @@ class CFSParameters:
         exceed the current power of each cfs slice based on a threshold
 
         :params cfs_spectrum:   Results of the CFS analysis
-        :type   cfs_spectrum:   dataclass
+        :type   cfs_spectrum:   OutputDataset dataclass from message_formats.py
         :params cfs_slices:     Slice ids of each cfs slice to be checked
         :type   cfs_slices:     list
         :params threshold:      Power threshold (dB) used in check
@@ -68,6 +68,9 @@ class CFSParameters:
                 <= self.last_cfs_power[slice_id][1] - threshold
             ):
                 self.set_new_freq = True
+            # Shift the current frequency down to baseband and then use the
+            # result to determine the index in the measured frequency
+            # spectrum that the current frequency is from
             shifted_frequency = self.last_cfs_power[slice_id][0] - int(
                 sum(self.cfs_range[slice_id]) / 2
             )
@@ -1083,7 +1086,7 @@ def main():
 
                             if (
                                 not cfs_params_dict[aveperiod].set_new_freq
-                                and aveperiod.cfs_pwr_threshold
+                                and aveperiod.cfs_pwr_threshold is not None
                             ):
                                 # If using a user set power threshold to trigger CFS freq setting, check
                                 # if any power related condition are triggered
@@ -1095,7 +1098,7 @@ def main():
 
                             if (
                                 cfs_params_dict[aveperiod].set_new_freq
-                                or not aveperiod.cfs_pwr_threshold
+                                or aveperiod.cfs_pwr_threshold is None
                             ):
                                 # If using a power threshold and one of the power conditions were
                                 # triggerd, or if not using a power threshold, set the CFS params

--- a/src/radar_control.py
+++ b/src/radar_control.py
@@ -102,7 +102,7 @@ class RadctrlParameters:
     pulse_transmit_data_tracker: dict = field(default_factory=dict)
     slice_dict: dict = field(default_factory=dict, init=False)
     cfs_scan_flag: bool = False
-    cfs_params: dict = CFSParameters()
+    cfs_params: dict = field(default_factory=CFSParameters)
     scan_flag: bool = False
     dsp_cfs_identity: str = ""
     router_address: str = ""

--- a/src/radar_control.py
+++ b/src/radar_control.py
@@ -1050,6 +1050,8 @@ def main():
                             cfs_params_dict[aveperiod].last_cfs_set_time
                             < time.time() - ave_params.aveperiod.cfs_stable_time
                         ):
+                            # Only let CFS run after the user set stable time has
+                            # passed to prevent CFS from switching freqs to quickly
                             ave_params.sequence = aveperiod.cfs_sequence
                             ave_params.decimation_scheme = (
                                 aveperiod.cfs_sequence.decimation_scheme
@@ -1064,14 +1066,24 @@ def main():
                             ave_params.num_sequences += 1
                             ave_params.cfs_scan_flag = False
 
-                            if not cfs_params_dict[aveperiod].set_new_freq:
+                            if (
+                                not cfs_params_dict[aveperiod].set_new_freq
+                                and aveperiod.cfs_pwr_threshold
+                            ):
+                                # If using a user set power threshold to trigger CFS freq setting, check
+                                # if any power related condition are triggered
                                 cfs_params_dict[aveperiod].check_update_freq(
                                     freq_spectrum,
                                     aveperiod.cfs_slice_ids,
                                     aveperiod.cfs_pwr_threshold,
                                 )
 
-                            if cfs_params_dict[aveperiod].set_new_freq:
+                            if (
+                                cfs_params_dict[aveperiod].set_new_freq
+                                or not aveperiod.cfs_pwr_threshold
+                            ):
+                                # If using a power threshold and one of the power conditions were
+                                # triggerd, or if not using a power threshold, set the CFS params
                                 cfs_params_dict[aveperiod].set_new_freq = False
                                 cfs_params_dict[
                                     aveperiod

--- a/src/radar_control.py
+++ b/src/radar_control.py
@@ -61,7 +61,7 @@ class RadctrlParameters:
     cfs_scan_flag: bool = False
     cfs_freq: list = field(default_factory=list)
     cfs_mags: list = field(default_factory=list)
-    cfs_range: list = field(default_factory=list)
+    cfs_range: list = field(default_factory=dict)
     cfs_masks: list = field(default_factory=dict)
     scan_flag: bool = False
     dsp_cfs_identity: str = ""
@@ -470,6 +470,7 @@ def create_dw_message(radctrl_params):
     message.cfs_noise = radctrl_params.cfs_mags
     message.cfs_range = radctrl_params.cfs_range
     message.cfs_masks = radctrl_params.cfs_masks
+    message.cfs_slice_ids = radctrl_params.aveperiod.cfs_slice_ids
 
     for sequence_index, sequence in enumerate(radctrl_params.aveperiod.sequences):
         sequence_add = messages.Sequence()
@@ -1034,11 +1035,10 @@ def main():
                         ave_params.cfs_mags = [
                             mag.cfs_data for mag in freq_spectrum.output_datasets
                         ]
-                        ave_params.cfs_range = [
-                            obj.cfs_range
-                            for sqn in aveperiod.cfs_sequences
-                            for obj in sqn.slice_dict.values()
-                        ]
+                        for ind in range(len(aveperiod.cfs_slice_ids)):
+                            ave_params.cfs_range[aveperiod.cfs_slice_ids[ind]] = (
+                                aveperiod.cfs_range[ind]
+                            )
                     # End CFS block
 
                     for sequence_index, sequence in enumerate(aveperiod.sequences):

--- a/src/radar_control.py
+++ b/src/radar_control.py
@@ -298,6 +298,8 @@ def create_dsp_message(radctrl_params):
     message.output_sample_rate = radctrl_params.sequence.output_rx_rate
     message.rx_ctr_freq = radctrl_params.sequence.rxctrfreq * 1.0e3
     message.cfs_scan_flag = radctrl_params.cfs_scan_flag
+    if radctrl_params.cfs_scan_flag:
+        message.cfs_fft_n = radctrl_params.aveperiod.cfs_fft_n
 
     if radctrl_params.decimation_scheme is not None:
         for stage in radctrl_params.decimation_scheme.stages:
@@ -1085,7 +1087,6 @@ def main():
                                     mag.cfs_data
                                     for mag in freq_spectrum.output_datasets
                                 ]
-                                log.info("Returned set freq of cfs", res=last_set_cfs)
 
                                 for ind in range(len(aveperiod.cfs_slice_ids)):
                                     cfs_params_dict[aveperiod].cfs_range[

--- a/src/rx_signal_processing.py
+++ b/src/rx_signal_processing.py
@@ -69,6 +69,7 @@ class RxProcessingParameters:
     samples_needed: int
     rx_rate: float
     output_sample_rate: float
+    cfs_fft_n: int
 
 
 def fill_datawrite_message(processed_data, slice_details, data_outputs, cfs_scan_flag):
@@ -220,7 +221,7 @@ def sequence_worker(options, ringbuffer):
             cfs_processor.apply_filters(sequence_samples)
             cfs_processor.move_filter_results()
             cfs_data, cfs_freq = cfs_processor.cfs_freq_analysis(
-                rx_params.slice_details[0]
+                rx_params.slice_details[0], rx_params.cfs_fft_n
             )
 
             del cfs_processor
@@ -518,6 +519,7 @@ def main():
         first_rx_sample_off = sqn_meta_message.offset_to_first_rx_sample
         rx_center_freq = sqn_meta_message.rx_ctr_freq
         cfs_scan_flag = sqn_meta_message.cfs_scan_flag
+        cfs_fft_n = sqn_meta_message.cfs_fft_n
 
         processed_data = ProcessedSequenceMessage()
 
@@ -701,6 +703,7 @@ def main():
             samples_needed,
             rx_rate,
             output_sample_rate,
+            cfs_fft_n,
         )
 
         sequence_worker_socket.send_pyobj(rx_params)

--- a/src/utils/message_formats.py
+++ b/src/utils/message_formats.py
@@ -133,6 +133,7 @@ class SequenceMetadataMessage:
     decimation_stages: list[DecimationStageMessage] = field(default_factory=list)
     rx_channels: list[RxChannel] = field(default_factory=list)
     cfs_scan_flag: bool = False
+    cfs_fft_n: int = None
 
     def add_decimation_stage(self, stage: DecimationStageMessage):
         """Add a decimation stage to the message."""

--- a/src/utils/message_formats.py
+++ b/src/utils/message_formats.py
@@ -251,6 +251,7 @@ class AveperiodMetadataMessage:
     cfs_noise: list = field(default_factory=list)
     cfs_range: list = field(default_factory=list)
     cfs_masks: list = field(default_factory=list)
+    cfs_slice_ids: list = field(default_factory=list)
 
     def add_sequence(self, sequence: dict):
         """Add a sequence dict to the message."""

--- a/src/utils/signals.py
+++ b/src/utils/signals.py
@@ -186,7 +186,7 @@ class DSP:
         data_chunks = np.reshape(data, data.shape[:-1] + (num_intervals, n))
 
         fft_data = fft.fftshift(fft.fft(data_chunks, axis=-1), axes=-1)
-        cfs_data = np.sum(np.abs(np.average(fft_data, axis=2)), axis=1)
+        cfs_data = 20 * np.log(np.sum(np.abs(np.average(fft_data, axis=2)), axis=1))
         cfs_freqs = fft.fftshift(fft.fftfreq(n, d=1 / fs))
 
         return cfs_data, cfs_freqs

--- a/src/utils/signals.py
+++ b/src/utils/signals.py
@@ -154,13 +154,16 @@ class DSP:
             self.antennas_iq_samples, beam_phases
         )
 
-    def cfs_freq_analysis(self, metadata):
+    def cfs_freq_analysis(self, metadata, n):
         """
         Performs decimation and frequency analysis on clear frequency search data. Data will not be
         in shared memory.
 
         :param  metadata:   Clear frequency search sequence metadata
         :type   metadata:   dict
+        :param  n:          Number of points used in the FFT. Determines the frequency resolution
+                            of where df = (rx_rate / total decimation rate) / N
+        :type   n:          int
         """
         fs = self.rx_rate / np.prod(self.dm_rates)  # Sampling frequency in Hz
 
@@ -173,12 +176,6 @@ class DSP:
             end_sample = int(round(pulses_in_samples[1] - pulse_dur / 2))
         else:
             end_sample = self.antennas_iq_samples.shape[-1]
-
-        # If FFT resolution should be determined first, then N calculated based on the rate
-        # n = int(round(fs / output_freq_resolution))
-
-        # If an N should be chosen and FFT resolution calculated based on N
-        n = 512  # An ideal size of fft
 
         num_intervals = int((end_sample - start_sample) / n)
         end_sample = start_sample + num_intervals * n


### PR DESCRIPTION
Added three new cfs parameters to allow users more control over the CFS performance:

**CFS Stable Time**
- Defines a minimum time during which once a CFS slice freq is set, it will not be changed again.
- Does not force CFS to change freq after time has passed
- Defined in number of seconds
- The CFS scan and processing are not run during the stable time

**CFS Power Threshold**
- Defines a power threshold in dB that must be surpassed before CFS changes a frequency for a slice
- Case 1: Another frequency within the cfs range is found to have a power lower than the power that the current frequency was at when it was set less the threshold power
- Case 2: The currently set frequency is found to have increased in power to a value greater than the original power when set plus the threshold power level
- Defaults to `None` when not set, so the CFS process always sets a new frequency when run 

**CFS FFT N**
- Allows the user to customize the frequency resolution of the CFS processing. 
- User must set the number of samples that will be used in the CFS processing FFTs.
- Defaults to 512 which gives a frequency resolution of around 620 Hz during regular operation.