### PR TITLE
Lock first pulse in sequence to next millisecond

### DIFF
--- a/src/usrp_drivers/usrp_driver.cpp
+++ b/src/usrp_drivers/usrp_driver.cpp
@@ -332,14 +332,13 @@ void transmit(zmq::context_t &driver_c, USRP &usrp_d,
       }
     } else {
       // round up to next millisecond
-      double milliseconds =
-          std::ceil(sequence_start_time.get_frac_secs() * 1000.0);
-      if (milliseconds > 999.0) {
+      double next_ms = std::ceil(sequence_start_time.get_frac_secs() * 1000.0);
+      if (next_ms > 999.0) {
         sequence_start_time =
             uhd::time_spec_t(sequence_start_time.get_full_secs() + 1, 0.0);
       } else {
         sequence_start_time = uhd::time_spec_t(
-            sequence_start_time.get_full_secs(), fractional_second / 1000.0);
+            sequence_start_time.get_full_secs(), next_ms / 1000.0);
       }
     }
 

--- a/src/usrp_drivers/usrp_driver.cpp
+++ b/src/usrp_drivers/usrp_driver.cpp
@@ -58,10 +58,10 @@ typedef struct {
 
 static clocks_t borealis_clocks;
 
-// The maximum allowed drift between the system and GPS times held in the borealis_clocks
-// variable. If the drift is larger than this, the module will crash to avoid writing
-// corrupt metadata to file.
-#define MAX_CLOCK_DRIFT 1000.0 // seconds
+// The maximum allowed drift between the system and GPS times held in the
+// borealis_clocks variable. If the drift is larger than this, the module will
+// crash to avoid writing corrupt metadata to file.
+#define MAX_CLOCK_DRIFT 1000.0  // seconds
 
 /**
  * @brief      Makes a set of vectors of the samples for each TX channel from
@@ -329,6 +329,17 @@ void transmit(zmq::context_t &driver_c, USRP &usrp_d,
       } else {
         sequence_start_time = uhd::time_spec_t(
             sequence_start_time.get_full_secs(), fractional_second);
+      }
+    } else {
+      // round up to next millisecond
+      double milliseconds =
+          std::ceil(sequence_start_time.get_frac_secs() * 1000.0);
+      if (milliseconds > 999.0) {
+        sequence_start_time =
+            uhd::time_spec_t(sequence_start_time.get_full_secs() + 1, 0.0);
+      } else {
+        sequence_start_time = uhd::time_spec_t(
+            sequence_start_time.get_full_secs(), fractional_second / 1000.0);
       }
     }
 


### PR DESCRIPTION
Starts the first pulse in a pulse sequence on a clean millisecond boundary.

Closes #489 