### PR TITLE
Remove `txdata` format

### DIFF
--- a/scripts/steamed_hams.py
+++ b/scripts/steamed_hams.py
@@ -181,17 +181,17 @@ elif args.run_mode == "pythonprofiling":
     mode = "debug"
     data_write_args = f"--enable-raw-acfs --enable-antenna-iq {rawacf_format}"
 elif args.run_mode == "testdata":
-    # run in scons release with python debug for tx data and print raw rf, for verifying data
+    # run in scons release with python debug for raw rf, for verifying data
     python_opts = "-u"
     c_debug_opts = ""
     mode = "release"
-    data_write_args = "--enable-tx --enable-raw-rf"
+    data_write_args = "--enable-raw-rf"
 elif args.run_mode == "engineeringdebug":
-    # run all modules in debug with tx and rawrf data - this mode is very slow
+    # run all modules in debug with rawrf data - this mode is very slow
     python_opts = "-u"
     c_debug_opts = "/usr/local/cuda/bin/cuda-gdb -ex start"
     mode = "debug"
-    data_write_args = "--enable-bfiq --enable-antenna-iq --enable-raw-rf --enable-tx;"
+    data_write_args = "--enable-bfiq --enable-antenna-iq --enable-raw-rf"
 elif args.run_mode == "filterdata":
     # run all modules in debug with rawrf, antennas_iq, and filter stage data.
     python_opts = "-u"

--- a/src/radar_control.py
+++ b/src/radar_control.py
@@ -458,12 +458,10 @@ def search_for_experiment(radar_control_to_exp_handler, exphan_to_radctrl_iden, 
 
 
 def make_next_samples(radctrl_params):
-    sqn, dbg = radctrl_params.sequence.make_sequence(
+    sqn = radctrl_params.sequence.make_sequence(
         radctrl_params.aveperiod.beam_iter,
         radctrl_params.num_sequences + len(radctrl_params.aveperiod.sequences),
     )
-    if dbg:
-        radctrl_params.debug_samples.append(dbg)
     radctrl_params.pulse_transmit_data_tracker[radctrl_params.sequence_index][
         radctrl_params.num_sequences + len(radctrl_params.aveperiod.sequences)
     ] = sqn
@@ -558,27 +556,6 @@ def create_dw_message(radctrl_params):
         sequence_add = messages.Sequence()
         sequence_add.blanks = sequence.blanks
         sequence_add.output_sample_rate = sequence.output_rx_rate
-
-        if len(radctrl_params.debug_samples) > 0:
-            tx_data = messages.TxData()
-            tx_data.tx_rate = radctrl_params.debug_samples[sequence_index]["txrate"]
-            tx_data.tx_ctr_freq = radctrl_params.debug_samples[sequence_index][
-                "txctrfreq"
-            ]
-            tx_data.pulse_timing_us = radctrl_params.debug_samples[sequence_index][
-                "pulse_timing"
-            ]
-            tx_data.pulse_sample_start = radctrl_params.debug_samples[sequence_index][
-                "pulse_sample_start"
-            ]
-            tx_data.tx_samples = radctrl_params.debug_samples[sequence_index][
-                "sequence_samples"
-            ]
-            tx_data.dm_rate = radctrl_params.debug_samples[sequence_index]["dmrate"]
-            tx_data.decimated_tx_samples = radctrl_params.debug_samples[sequence_index][
-                "decimated_samples"
-            ]
-            sequence_add.tx_data = tx_data
 
         for slice_id in sequence.slice_ids:
             sqn_slice = sequence.slice_dict[slice_id]
@@ -1212,11 +1189,9 @@ def main():
                         # On first sequence, we make the first set of samples
                         if sequence_index not in ave_params.pulse_transmit_data_tracker:
                             ave_params.pulse_transmit_data_tracker[sequence_index] = {}
-                            sqn, dbg = sequence.make_sequence(
+                            sqn = sequence.make_sequence(
                                 aveperiod.beam_iter, ave_params.num_sequences
                             )
-                            if dbg:
-                                ave_params.debug_samples.append(dbg)
                             ave_params.pulse_transmit_data_tracker[sequence_index][
                                 ave_params.num_sequences
                             ] = sqn

--- a/src/utils/file_formats.py
+++ b/src/utils/file_formats.py
@@ -635,7 +635,7 @@ class SliceData:
     )
     tx_antennas: list[int] = field(
         metadata={
-            "groups": ["antennas_iq", "bfiq", "rawacf", "rawrf", "txdata"],
+            "groups": ["antennas_iq", "bfiq", "rawacf", "rawrf"],
             "level": "file",
             "description": "Indices into ``antenna_locations`` of the antennas used for transmitting in this experiment",
             "nickname": "tx antenna",
@@ -644,7 +644,7 @@ class SliceData:
     )
     tx_antenna_phases: np.ndarray = field(
         metadata={
-            "groups": ["antennas_iq", "bfiq", "rawacf", "rawrf", "txdata"],
+            "groups": ["antennas_iq", "bfiq", "rawacf", "rawrf"],
             "level": "record",
             "units": "a.u.",
             "description": "Phases of transmit signal for each antenna. Magnitude between 0 (off) and 1 (full power)",

--- a/src/utils/file_formats.py
+++ b/src/utils/file_formats.py
@@ -227,8 +227,8 @@ class SliceData:
             "level": "record",
             "units": "a.u. ~ V",
             "description": "Samples decimated by dm_rate",
-            "dim_labels": ["antenna", "sequence", "time"],
-            "dim_scales": ["tx_antennas", "sqn_timestamps", "sample_time"],
+            "dim_labels": ["sequence", "antenna", "time"],
+            # "dim_scales": ["tx_antennas", "sqn_timestamps", "sample_time"],
             "required": True,
         }
     )
@@ -598,7 +598,7 @@ class SliceData:
     )
     sqn_timestamps: list[float] = field(
         metadata={
-            "groups": ["antennas_iq", "bfiq", "rawacf", "rawrf"],
+            "groups": ["antennas_iq", "bfiq", "rawacf", "rawrf", "txdata"],
             "level": "record",
             "nickname": "timestamp",
             "units": "seconds since 1970-01-01 00:00:00 UTC",
@@ -635,7 +635,7 @@ class SliceData:
     )
     tx_antennas: list[int] = field(
         metadata={
-            "groups": ["antennas_iq", "bfiq", "rawacf", "rawrf"],
+            "groups": ["antennas_iq", "bfiq", "rawacf", "rawrf", "txdata"],
             "level": "file",
             "description": "Indices into ``antenna_locations`` of the antennas used for transmitting in this experiment",
             "nickname": "tx antenna",
@@ -687,7 +687,7 @@ class SliceData:
             "units": "a.u. ~ V",
             "description": "Samples sent to USRPs for transmission",
             "dim_labels": ["sequence", "antenna", "time"],
-            "dim_scales": ["sqn_timestamps", "tx_antennas", "sample_time"],
+            # "dim_scales": ["sqn_timestamps", "tx_antennas", "sample_time"],
             "required": True,
         }
     )

--- a/src/utils/file_formats.py
+++ b/src/utils/file_formats.py
@@ -227,9 +227,11 @@ class SliceData:
             "level": "record",
             "units": "a.u. ~ V",
             "description": "Samples decimated by dm_rate",
+            "dim_labels": ["antenna", "sequence", "time"],
+            "dim_scales": ["tx_antennas", "sqn_timestamps", "sample_time"],
             "required": True,
         }
-    )  # todo: Is this after each stage, or just the final samples?
+    )
     dm_rate: list[int] = field(
         metadata={
             "groups": ["txdata"],
@@ -237,7 +239,7 @@ class SliceData:
             "description": "Total decimation rate of the filtering scheme",
             "required": True,
         }
-    )  # todo: Is this supposed to be a list of ALL dm_rates, or just the total?
+    )
     experiment_comment: str = field(
         metadata={
             "groups": ["antennas_iq", "bfiq", "rawacf", "rawrf"],
@@ -410,22 +412,22 @@ class SliceData:
             "required": False,
         }
     )
-    pulse_sample_start: list[float] = field(
+    pulse_sample_start: list[np.ndarray] = field(
         metadata={
             "groups": ["txdata"],
             "level": "file",
             "description": "Beginning of pulses in sequence measured in samples",
-            "dim_labels": ["pulse"],
+            "dim_labels": ["sequence", "pulse"],
             "required": True,
         }
     )
-    pulse_timing: list[float] = field(
+    pulse_timing: list[np.ndarray] = field(
         metadata={
             "groups": ["txdata"],
             "level": "file",
             "units": "μs",
             "description": "Relative timing of pulse start for all pulses in the sequence",
-            "dim_labels": ["pulse"],
+            "dim_labels": ["sequence", "pulse"],
             "required": True,
         }
     )
@@ -651,7 +653,7 @@ class SliceData:
             "required": False,
         }
     )
-    tx_center_freq: list[float] = field(  # todo: Why is this a list?
+    tx_center_freq: float = field(
         metadata={
             "groups": ["txdata"],
             "level": "file",
@@ -669,7 +671,7 @@ class SliceData:
             "required": True,
         }
     )
-    tx_rate: list[float] = field(
+    tx_rate: float = field(
         metadata={
             "groups": ["txdata"],
             "level": "file",
@@ -677,15 +679,15 @@ class SliceData:
             "description": "Sampling rate of the samples being sent to the USRPs",
             "required": True,
         }
-    )  # todo: Why is this a list? Shouldn't it be a single number?
-    tx_samples: list = field(
+    )
+    tx_samples: list[np.ndarray] = field(
         metadata={
             "groups": ["txdata"],
             "level": "record",
             "units": "a.u. ~ V",
             "description": "Samples sent to USRPs for transmission",
-            "dim_labels": ["antenna", "time"],  # todo: verify
-            "dim_scales": ["tx_antennas", "sample_time"],
+            "dim_labels": ["sequence", "antenna", "time"],
+            "dim_scales": ["sqn_timestamps", "tx_antennas", "sample_time"],
             "required": True,
         }
     )
@@ -972,7 +974,7 @@ class SliceData:
             if isinstance(data, dict):
                 data = str(data)
             elif isinstance(data, str):
-                data = data.encode('utf-8')
+                data = data.encode("utf-8")
             elif isinstance(data, list):
                 if isinstance(data[0], str):
                     data = np.bytes_(data)
@@ -985,7 +987,9 @@ class SliceData:
                 group[relevant_field] = data
 
         FILENAME = ""  # todo: Use the name of the rawacf file? Or just the timestamp of the start of the file?
-        dmap_record = pydarnio.BorealisV1Convert.convert_rawacf_record(group, metadata, FILENAME)
+        dmap_record = pydarnio.BorealisV1Convert.convert_rawacf_record(
+            group, metadata, FILENAME
+        )
 
         return dmap_record
 

--- a/src/utils/file_formats.py
+++ b/src/utils/file_formats.py
@@ -5,7 +5,7 @@ file_formats
 Contains the dataclass `SliceData` defining the data and metadata that is stored in files produced by borealis.
 
 `SliceData` fields contain associated metadata that determines which file types (`rawrf`, `antennas_iq`, `bfiq`,
-`rawacf`, and `txdata`) should contain the aforementioned field, and at which level (`file` or `record`) the field
+`rawacf`) should contain the aforementioned field, and at which level (`file` or `record`) the field
 should be written. Fields at the `file` level are written only once, with the associated data immutable throughout
 the experiment for the given slice. Fields at the `record` level are written to each averaging period, within the record
 for that averaging period.
@@ -73,7 +73,7 @@ class SliceData:
     )
     antenna_locations: np.ndarray = field(
         metadata={
-            "groups": ["antennas_iq", "bfiq", "rawacf", "rawrf", "txdata"],
+            "groups": ["antennas_iq", "bfiq", "rawacf", "rawrf"],
             "level": "file",
             "units": "m",
             "description": "Relative antenna locations",
@@ -83,7 +83,7 @@ class SliceData:
     )
     antennas: np.ndarray = field(
         metadata={
-            "groups": ["antennas_iq", "bfiq", "rawacf", "rawrf", "txdata"],
+            "groups": ["antennas_iq", "bfiq", "rawacf", "rawrf"],
             "level": "file",
             "description": "Labels for each antenna of the radar",
             "dim_labels": ["antenna"],
@@ -206,7 +206,7 @@ class SliceData:
     )
     coordinates: list[str] = field(
         metadata={
-            "groups": ["antennas_iq", "bfiq", "rawacf", "rawrf", "txdata"],
+            "groups": ["antennas_iq", "bfiq", "rawacf", "rawrf"],
             "level": "file",
             "description": "Descriptors for location coordinate dimensions",
             "nickname": "coordinate",
@@ -218,25 +218,6 @@ class SliceData:
             "groups": ["antennas_iq", "bfiq", "rawacf"],
             "level": "file",
             "description": "Cumulative scale of all of the filters for a total scaling factor to normalize by",
-            "required": True,
-        }
-    )
-    decimated_tx_samples: list = field(
-        metadata={
-            "groups": ["txdata"],
-            "level": "record",
-            "units": "a.u. ~ V",
-            "description": "Samples decimated by dm_rate",
-            "dim_labels": ["sequence", "antenna", "time"],
-            # "dim_scales": ["tx_antennas", "sqn_timestamps", "sample_time"],
-            "required": True,
-        }
-    )
-    dm_rate: list[int] = field(
-        metadata={
-            "groups": ["txdata"],
-            "level": "file",
-            "description": "Total decimation rate of the filtering scheme",
             "required": True,
         }
     )
@@ -412,25 +393,6 @@ class SliceData:
             "required": False,
         }
     )
-    pulse_sample_start: list[np.ndarray] = field(
-        metadata={
-            "groups": ["txdata"],
-            "level": "file",
-            "description": "Beginning of pulses in sequence measured in samples",
-            "dim_labels": ["sequence", "pulse"],
-            "required": True,
-        }
-    )
-    pulse_timing: list[np.ndarray] = field(
-        metadata={
-            "groups": ["txdata"],
-            "level": "file",
-            "units": "μs",
-            "description": "Relative timing of pulse start for all pulses in the sequence",
-            "dim_labels": ["sequence", "pulse"],
-            "required": True,
-        }
-    )
     pulses: np.ndarray = field(
         metadata={
             "groups": ["antennas_iq", "bfiq", "rawacf"],
@@ -598,7 +560,7 @@ class SliceData:
     )
     sqn_timestamps: list[float] = field(
         metadata={
-            "groups": ["antennas_iq", "bfiq", "rawacf", "rawrf", "txdata"],
+            "groups": ["antennas_iq", "bfiq", "rawacf", "rawrf"],
             "level": "record",
             "nickname": "timestamp",
             "units": "seconds since 1970-01-01 00:00:00 UTC",
@@ -635,7 +597,7 @@ class SliceData:
     )
     tx_antennas: list[int] = field(
         metadata={
-            "groups": ["antennas_iq", "bfiq", "rawacf", "rawrf", "txdata"],
+            "groups": ["antennas_iq", "bfiq", "rawacf", "rawrf"],
             "level": "file",
             "description": "Indices into ``antenna_locations`` of the antennas used for transmitting in this experiment",
             "nickname": "tx antenna",
@@ -653,41 +615,12 @@ class SliceData:
             "required": False,
         }
     )
-    tx_center_freq: float = field(
-        metadata={
-            "groups": ["txdata"],
-            "level": "file",
-            "units": "kHz",
-            "description": "Center frequency of the transmitted data in kHz",
-            "required": True,
-        }
-    )
     tx_pulse_len: float = field(
         metadata={
             "groups": ["antennas_iq", "bfiq", "rawacf"],
             "level": "file",
             "units": "μs",
             "description": "Length of the pulse in microseconds",
-            "required": True,
-        }
-    )
-    tx_rate: float = field(
-        metadata={
-            "groups": ["txdata"],
-            "level": "file",
-            "units": "Hz",
-            "description": "Sampling rate of the samples being sent to the USRPs",
-            "required": True,
-        }
-    )
-    tx_samples: list[np.ndarray] = field(
-        metadata={
-            "groups": ["txdata"],
-            "level": "record",
-            "units": "a.u. ~ V",
-            "description": "Samples sent to USRPs for transmission",
-            "dim_labels": ["sequence", "antenna", "time"],
-            # "dim_scales": ["sqn_timestamps", "tx_antennas", "sample_time"],
             "required": True,
         }
     )

--- a/src/utils/message_formats.py
+++ b/src/utils/message_formats.py
@@ -203,24 +203,10 @@ class RxChannelMetadata:
 
 
 @dataclass
-class TxData:
-    """Defines a tx_data structure for inclusion in a Sequence dataclass"""
-
-    tx_rate: float = None
-    tx_ctr_freq: float = None
-    pulse_timing_us: list[int] = None
-    pulse_sample_start: list[int] = None
-    tx_samples: np.ndarray = None  # [num_antennas, num_samples]
-    dm_rate: int = None
-    decimated_tx_samples: np.ndarray = None  # [num_antennas, num_samples/dm_rate]
-
-
-@dataclass
 class Sequence:
     """Defines a sequence structure for inclusion in an AveperiodMetadataMessage"""
 
     blanks: list[int] = field(default_factory=list)
-    tx_data: TxData = None
     output_sample_rate: float = None
     rx_channels: list[RxChannelMetadata] = field(default_factory=list)
 

--- a/src/utils/message_formats.py
+++ b/src/utils/message_formats.py
@@ -208,8 +208,8 @@ class TxData:
 
     tx_rate: float = None
     tx_ctr_freq: float = None
-    pulse_timing_us: int = None
-    pulse_sample_start: int = None
+    pulse_timing_us: list[int] = None
+    pulse_sample_start: list[int] = None
     tx_samples: np.ndarray = None  # [num_antennas, num_samples]
     dm_rate: int = None
     decimated_tx_samples: np.ndarray = None  # [num_antennas, num_samples/dm_rate]

--- a/tests/simulators/steamed_sham.py
+++ b/tests/simulators/steamed_sham.py
@@ -189,13 +189,13 @@ elif args.run_mode == "testdata":
     python_opts = "-u"
     c_debug_opts = ""
     mode = "release"
-    data_write_args = "--enable-tx --enable-raw-rf"
+    data_write_args = "--enable-raw-rf"
 elif args.run_mode == "engineeringdebug":
     # run all modules in debug with tx and rawrf data - this mode is very slow
     python_opts = "-u"
     c_debug_opts = "/usr/local/cuda/bin/cuda-gdb -ex start"
     mode = "debug"
-    data_write_args = "--enable-bfiq --enable-antenna-iq --enable-raw-rf --enable-tx;"
+    data_write_args = "--enable-bfiq --enable-antenna-iq --enable-raw-rf"
 elif args.run_mode == "filterdata":
     # run all modules in debug with rawrf, antennas_iq, and filter stage data.
     python_opts = "-u"


### PR DESCRIPTION
The format is used only for commissioning a Borealis system, and even so rarely. Instead, we rely on oscilloscope measurements or loopback tests to ensure that the transmitted samples are correct.