### PR TITLE
Fixing bug of filter stage data being copies of antennas_iq data

### DIFF
--- a/src/data_write.py
+++ b/src/data_write.py
@@ -517,14 +517,11 @@ class DataWrite:
                     / stage_data.rx_sample_rate
                 )
                 stage_data.sample_time = sample_timing_s * 1e6
-                final_data_params[slice_num][stage] = stage_data
 
-        for slice_num, slice_ in final_data_params.items():
-            for stage, params in slice_.items():
                 two_hr_file_with_type = self.slice_filenames[slice_num].format(
                     ext=f"{stage}_iq"
                 )
-                self._write_file(params, two_hr_file_with_type, "antennas_iq")
+                self._write_file(stage_data, two_hr_file_with_type, "antennas_iq")
 
     def _write_raw_rf_params(
         self, slice_data: SliceData, parsed_data: Aggregator, sample_rate: float


### PR DESCRIPTION
The internal `SliceData` object has an `antennas_iq_data` field that was being overwritten by each subsequent stage before the stage was written, so all stage files would have the final stage's data written.