### PR TITLE
Pulse gen

### DIFF
--- a/src/experiment_prototype/interface_classes/sequences.py
+++ b/src/experiment_prototype/interface_classes/sequences.py
@@ -20,7 +20,6 @@ from functools import reduce
 import inspect
 import math
 from pathlib import Path
-from src.utils.signals import basic_pulse_phase_offset
 
 # third-party
 import numpy as np
@@ -31,7 +30,7 @@ from experiment_prototype.interface_classes.interface_class_base import (
     InterfaceClassBase,
 )
 from experiment_prototype.experiment_exception import ExperimentException
-from utils.signals import get_samples, get_phase_shift
+from utils.signals import get_samples, get_phase_shift, basic_pulse_phase_offset
 
 # Obtain the module name that imported this log_config
 caller = Path(inspect.stack()[-1].filename)

--- a/src/radar_control.py
+++ b/src/radar_control.py
@@ -26,7 +26,6 @@ from experiment_prototype.interface_classes.averaging_periods import CFSAveragin
 from utils.options import Options
 import utils.message_formats as messages
 from utils import socket_operations as so
-from utils.signals import calc_pulse_base_offset
 
 sys.path.append(os.environ["BOREALISPATH"])
 if __debug__:
@@ -360,23 +359,13 @@ def create_dsp_message(radctrl_params):
 
             # Get the phase offset for this pulse combination
             pulse_phase_offsets = radctrl_params.sequence.output_encodings
-            base_pulse_offset = calc_pulse_base_offset(slice_dict[slice_id])
-            if len(pulse_phase_offsets[slice_id]) != 0 or base_pulse_offset is not None:
-                if len(pulse_phase_offsets[slice_id]) != 0:
-                    pulse_phase_offset = pulse_phase_offsets[slice_id][-1]
-                else:
-                    pulse_phase_offset = np.zeros(len(base_pulse_offset))
+            if len(pulse_phase_offsets[slice_id]) != 0:
+                pulse_phase_offset = pulse_phase_offsets[slice_id][-1]
                 lag0_idx = slice_dict[slice_id].pulse_sequence.index(lag[0])
                 lag1_idx = slice_dict[slice_id].pulse_sequence.index(lag[1])
-                if base_pulse_offset is not None:
-                    phase_in_rad = np.radians(
-                        (pulse_phase_offset[lag0_idx] - base_pulse_offset[lag0_idx])
-                        - (pulse_phase_offset[lag1_idx] - base_pulse_offset[lag1_idx])
-                    )
-                else:
-                    phase_in_rad = np.radians(
-                        pulse_phase_offset[lag0_idx] - pulse_phase_offset[lag1_idx]
-                    )
+                phase_in_rad = np.radians(
+                    pulse_phase_offset[lag0_idx] - pulse_phase_offset[lag1_idx]
+                )
                 phase_offset = np.exp(1j * np.array(phase_in_rad, np.float32))
             # Catch case where no pulse phase offsets are specified
             else:

--- a/src/utils/signals.py
+++ b/src/utils/signals.py
@@ -539,7 +539,7 @@ def basic_pulse_phase_offset(exp_slice):
     """
     freq_hz = exp_slice.freq * 1e3
     tau_s = exp_slice.tau_spacing / 1e6
-    omega = -2 * np.pi * freq_hz
+    omega = 2 * np.pi * freq_hz
     pulse_sequence = exp_slice.pulse_sequence
 
     num_pulses = len(pulse_sequence)

--- a/src/utils/signals.py
+++ b/src/utils/signals.py
@@ -526,22 +526,16 @@ def get_samples(rate, wave_freq, pulse_len, ramp_time, max_amplitude):
     return samples
 
 
-def calc_pulse_base_offset(exp_slice):
+def basic_pulse_phase_offset(exp_slice):
     """
-    Determine the phase offset of each pulse from the first pulse based on the
-    transmit frequency and the pulse separation (tau spacing). Required due to
-    phase shift that occurs when the signal is shifted down to baseband due to
-    the construction of the pulses and the frequency shift that will be applied
-    to shift to baseband. When the frequency is not a multiple of 10 kHz (or
-    when the pulse transmit delay from first pulse is not an integer multiple
-    of 1 ms), the lag pulses become out of phase introducing an artificial
-    velocity shift in the rawacf data.
+    Calculate the phase difference of each pulse with respect to the first
+    pulse based on the transmit frequency and the pulse separation.
 
     :param      exp_slice:  The experiment slice information
     :type       exp_slice:  class
 
-    :returns:   Base pulse phase offsets when shifting to baseband.
-    :rtype:     array (deg) or None (if all phases are the same)
+    :returns:   Pulse phase offsets
+    :rtype:     array (rad)
     """
     freq_hz = exp_slice.freq * 1e3
     tau_s = exp_slice.tau_spacing / 1e6
@@ -552,9 +546,6 @@ def calc_pulse_base_offset(exp_slice):
     pulse_phases = np.zeros(num_pulses)
     for p in range(num_pulses):
         pulse_time = pulse_sequence[p] * tau_s
-        pulse_phases[p] = np.rad2deg(np.angle(np.exp(1j * omega * pulse_time)))
-
-    if all(np.isclose(pulse_phases, pulse_phases[0], atol=1e-6)):
-        pulse_phases = None
+        pulse_phases[p] = np.angle(np.exp(1j * omega * pulse_time))
 
     return pulse_phases


### PR DESCRIPTION
Changed how pulses are generated for each sequence. Instead of creating a sequence of all identical pulses, the basic pulse that is generated is phase shifted based on where the pulse occurs in the sequence with respect to the first pulse of the sequence. 

This is applying the same operation as the pulse offset correction implemented earlier, except instead of adjusting the pulse phases upon reception, they are being adjusted before being sent out. As such the phase correction step implemented in radar control has also been removed. Now pulse phases are only adjusted at reception if the user had defined pulse phase offsets in the experiment.