### PR TITLE
Add APCUPSD scripts to start/stop radar during power outages

### DIFF
--- a/docs/source/starting_the_radar.rst
+++ b/docs/source/starting_the_radar.rst
@@ -42,7 +42,7 @@ module will not be run. For example::
     /home/radar/borealis/scripts/steamed_hams.py normalscan release discretionary --realtime-off
 
 If starting the radar in normal operation according to the schedule, there is a helper script called
-``start_radar.sh``.
+``start_radar.sh``, shown :ref:`below <start_radar-sh>`.
 
 ------------------
 Automated Start-up
@@ -60,7 +60,6 @@ This script should be added to the control computer boot-up scripts so that it g
 of scheduled commands.
 
 .. _automated-restarts:
-
 ------------------
 Automated Restarts
 ------------------
@@ -108,8 +107,9 @@ There are several ways to stop the Borealis radar. They are ranked here from mos
 last-resort:
 
 #. Run the script ``stop_radar.sh`` from the Borealis ``scripts/`` directory. This script kills the
-   scheduling server, removes all entries from the schedule and kills the screen session running the
-   Borealis software modules. ``stop_radar.sh`` is shown :ref:`below <stop_radar-sh>`.
+   scheduling server, removes all scheduled entries from the ``at`` queue and kills the screen
+   session running the Borealis software modules. ``stop_radar.sh`` is shown :ref:`below
+   <stop_radar-sh>`.
 
 #. While viewing the screen session running the Borealis software modules, type ``ctrl-A, ctrl-\\``.
    This will kill the screen session and all software modules running within it.
@@ -118,6 +118,31 @@ last-resort:
    start back up again once the computer reboots.
 
 #. Shut down the Borealis computer.
+
+
+-------------------
+UPS & Power Outages
+-------------------
+
+To protect the Borealis computer from power outages and ensure the computer can safely turn off, the
+computer should be powered by an Uninterruptible Power Supply (UPS). Additionally, powering the
+Borealis hardware (N200s, octoclocks, and network equipment) with the UPS will mitigate potential
+radar restarts due to power brownouts or short power outages. In this scenario, the UPS should shut
+temporarily turn off the radar while the Borealis equipment is on battery power during the power
+outage (since the transmitters will be powered off). This can be done as follows:
+
+1. Use ``apcupsd`` to communicate between the radar computer and the UPS. Follow the `APCUPSD User
+   Manual <https://web.archive.org/web/20220815033620/http://www.apcupsd.org/manual/manual.html>`__
+   to install and configure for your setup.
+2. Copy the ``offbattery`` and ``onbattery`` scripts from ``borealis/scripts/apcupsd/`` to
+   ``/etc/apcupsd/``. These scripts will be executed when each event occurs on the UPS:
+
+   1. ``onbattery``: This occurs when the power outage starts. This script will schedule the radar
+      to turn off via ``stop_radar.sh``, and stop the ``restart_borealis.service`` daemon so the
+      radar doesn't restart during the power outage.
+   2. ``offbattery``: This occurs when the power outage ends. This script will cancel the scheduled
+      ``stop_radar.sh`` script call, and restart the ``restart_borealis.service`` daemon.
+
 
 -------
 Scripts

--- a/docs/source/starting_the_radar.rst
+++ b/docs/source/starting_the_radar.rst
@@ -60,6 +60,7 @@ This script should be added to the control computer boot-up scripts so that it g
 of scheduled commands.
 
 .. _automated-restarts:
+
 ------------------
 Automated Restarts
 ------------------

--- a/scripts/apcupsd/offbattery
+++ b/scripts/apcupsd/offbattery
@@ -1,0 +1,29 @@
+#!/bin/sh
+#
+# This shell script if placed in /etc/apcupsd will be called by /etc/apcupsd/apccontrol when the
+# UPS goes back on to the mains after a power failure.
+
+
+# Send signal to start Borealis, or check if the stop_radar.sh process was called by onbattery and
+# cancel it
+SCRIPT_DIR="/home/radar/borealis/scripts/"
+PID_FILE="/tmp/stop_radar.pid"
+
+# First, check if this computer is running Borealis:
+NOW=$(date +'%Y-%m-%d %H:%M:%S')
+if systemctl status restart_borealis.service > /dev/null 2>&1; then
+        PID=$(cat $PID_FILE)
+        if kill -0 "$PID" >/dev/null 2>&1; then
+                # stop_radar.sh hasn't executed yet - cancel it
+                echo "$NOW Cancelling the scheduled stop_radar.sh (PID $PID) command"
+                pkill -9 -P "$PID"
+                # Radar should still be running, so no need to start it
+        else
+                # stop_radar.sh finished, so radar is not running. Start it.
+                echo "$NOW Radar not running - executing start_radar.sh"
+                sudo -u radar ${SCRIPT_DIR}start_radar.sh
+        fi
+        rm $PID_FILE
+fi
+
+exit 0

--- a/scripts/apcupsd/offbattery
+++ b/scripts/apcupsd/offbattery
@@ -2,28 +2,35 @@
 #
 # This shell script if placed in /etc/apcupsd will be called by /etc/apcupsd/apccontrol when the
 # UPS goes back on to the mains after a power failure.
+#
+# Must be run as root
 
 
 # Send signal to start Borealis, or check if the stop_radar.sh process was called by onbattery and
 # cancel it
-SCRIPT_DIR="/home/radar/borealis/scripts/"
-PID_FILE="/tmp/stop_radar.pid"
+HOME="/home/radar"
+SCRIPT_DIR="${HOME}/borealis/scripts"
+PID_FILE="${HOME}/borealis/stop_radar.pid"
+FLAG_FILE="${HOME}/borealis/apcusd.flag"
 
-# First, check if this computer is running Borealis:
-NOW=$(date +'%Y-%m-%d %H:%M:%S')
-if systemctl status restart_borealis.service > /dev/null 2>&1; then
+# First, check if this computer was running Borealis. If it was, then onbattery should have created
+# a flag file, letting this script know it needs to turn the restart_borealis service back on
+NOW=$(date +'%Y-%m-%d %H:%M:%S %z ')
+if [[ -f $FLAG_FILE ]]; then
         PID=$(cat $PID_FILE)
         if kill -0 "$PID" >/dev/null 2>&1; then
                 # stop_radar.sh hasn't executed yet - cancel it
                 echo "$NOW Cancelling the scheduled stop_radar.sh (PID $PID) command"
                 pkill -9 -P "$PID"
-                # Radar should still be running, so no need to start it
-        else
-                # stop_radar.sh finished, so radar is not running. Start it.
-                echo "$NOW Radar not running - executing start_radar.sh"
-                sudo -u radar ${SCRIPT_DIR}start_radar.sh
         fi
+
+        # The restart_borealis service will start the radar if it isn't already running and handle
+        # any further restarts.
+        systemctl restart restart_borealis.service
+
+        # Clean up temporary files
         rm $PID_FILE
+        rm $FLAG_FILE
 fi
 
 exit 0

--- a/scripts/apcupsd/onbattery
+++ b/scripts/apcupsd/onbattery
@@ -2,21 +2,35 @@
 #
 # This shell script if placed in /etc/apcupsd will be called by /etc/apcupsd/apccontrol when the UPS
 # goes on batteries.
+#
+# Must be run as root
 
 
 # Send signal to stop Borealis, but wait a specified time. If offbattery is called within the
 # specified time, Borealis won't be shut off.
-SCRIPT_DIR="/home/radar/borealis/scripts/"
-WAIT_TIME=30 # 30s
+HOME="/home/radar"
+SCRIPT_DIR="${HOME}/borealis/scripts"
+PID_FILE="${HOME}/borealis/stop_radar.pid"
+FLAG_FILE="${HOME}/borealis/apcusd.flag"
+
+WAIT_TIME=30    # seconds
 
 # First, check if this computer is running Borealis by checking the restart_borealis service:
-NOW=$(date +'%Y-%m-%d %H:%M:%S')
+NOW=$(date +'%Y-%m-%d %H:%M:%S %z ')
 if systemctl status restart_borealis.service > /dev/null 2>&1; then
         # Run command in the background to not block apcupsd
-        (sleep $WAIT_TIME && sudo -u radar ${SCRIPT_DIR}stop_radar.sh) &
-        # Save the PID of stop_radar.sh, so it can be stopped by offbattery if needed
-        echo $! > /tmp/stop_radar.pid
-        echo "$NOW Scheduled stop_radar.sh (PID $(cat /tmp/stop_radar.pid)) to run in ${WAIT_TIME}s"
+        (sleep $WAIT_TIME && sudo -u radar ${SCRIPT_DIR}/stop_radar.sh) &
+
+        # Save the PID of stop_radar.sh
+        echo $! > $PID_FILE
+
+        # Stop restart_borealis service during power outage
+        systemctl stop restart_borealis.service
+
+        # Create a flag file to indicate to offbattery that this computer
+        touch $FLAG_FILE
+
+        echo "$NOW Scheduled stop_radar.sh (PID $(cat $PID_FILE )) to run in ${WAIT_TIME}s"
 fi
 
 exit 0

--- a/scripts/apcupsd/onbattery
+++ b/scripts/apcupsd/onbattery
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+# This shell script if placed in /etc/apcupsd will be called by /etc/apcupsd/apccontrol when the UPS
+# goes on batteries.
+
+
+# Send signal to stop Borealis, but wait a specified time. If offbattery is called within the
+# specified time, Borealis won't be shut off.
+SCRIPT_DIR="/home/radar/borealis/scripts/"
+WAIT_TIME=30 # 30s
+
+# First, check if this computer is running Borealis by checking the restart_borealis service:
+NOW=$(date +'%Y-%m-%d %H:%M:%S')
+if systemctl status restart_borealis.service > /dev/null 2>&1; then
+        # Run command in the background to not block apcupsd
+        (sleep $WAIT_TIME && sudo -u radar ${SCRIPT_DIR}stop_radar.sh) &
+        # Save the PID of stop_radar.sh, so it can be stopped by offbattery if needed
+        echo $! > /tmp/stop_radar.pid
+        echo "$NOW Scheduled stop_radar.sh (PID $(cat /tmp/stop_radar.pid)) to run in ${WAIT_TIME}s"
+fi
+
+exit 0

--- a/scripts/start_radar.sh
+++ b/scripts/start_radar.sh
@@ -14,7 +14,7 @@ nohup python3 $BOREALISPATH/scheduler/remote_server.py \
 PID=$!	# Get pid of remote_server.py process
 sleep 1
 
-NOW=$(date +'%Y%m%d %H:%M:%S')
+NOW=$(date +'%Y-%m-%d %H:%M:%S')
 if ! ps -p $PID &> /dev/null; then	 # Check if remote_server.py process still running
 	echo "${NOW} START: FAIL - remote_server.py failed to start." | tee -a $LOGFILE
 	exit 1

--- a/scripts/stop_radar.sh
+++ b/scripts/stop_radar.sh
@@ -2,8 +2,13 @@
 source "/home/radar/.profile"
 LOGFILE="/home/radar/logs/start_stop.log"
 
+NOW=$(date +'%Y-%m-%d %H:%M:%S')
+
 # Kill remote_server.py process
 PID=$(pgrep -f remote_server.py) # Get PID of remote_server.py process
+if [[ -z $PID ]]; then
+	echo "$NOW STOP: NOTE - remote_server.py is not running"
+fi
 pkill -9 -f remote_server.py
 
 # Remove all scheduled experiments from at queue
@@ -18,16 +23,18 @@ if screen -ls | grep -q borealis; then
 	# Kill Borealis processes
 	screen -X -S borealis quit
 	retVal=$?
+else
+	echo "$NOW STOP: FAIL - Radar not running, no Borealis screens found"
+	exit 1
 fi
 
 sleep 1
-NOW=$(date +'%Y%m%d %H:%M:%S')
-if ps -p $PID &> /dev/null; then	 # Check if remote_server.py process still running
+if ps -p $PID &> /dev/null; then	# Check if remote_server.py process still running
 	echo "${NOW} STOP: FAIL - could not kill remote_server.py process." | tee -a $LOGFILE
 	exit 1
 fi
 
-if [[ -n $(atq) ]]; then		# Check if atq is not empty
+if [[ -n $(atq) ]]; then			# Check if atq is not empty
 	echo "${NOW} STOP: FAIL - could not clear atq. Radar processes still scheduled." | tee -a $LOGFILE
 	exit 1
 fi


### PR DESCRIPTION
Added scripts used by `apcupsd` to start and stop the radar when during power outages. 