### PR TITLE
Shm pulses

### DIFF
--- a/config/cly/cly_config.ini
+++ b/config/cly/cly_config.ini
@@ -172,6 +172,8 @@
     "realtime_address" : "tcp://127.0.0.1:9696",
     "ringbuffer_name": "data_ringbuffer",
     "ringbuffer_size_bytes" : "200e6",
+    "pulse_buffer_name": "pulse_buffer",
+    "pulse_buffer_size": "1000000",
     "data_directory" : "/data/borealis_data",
     "rawacf_format" : "dmap",
     "log_handlers" : {

--- a/config/inv/inv_config.ini
+++ b/config/inv/inv_config.ini
@@ -172,6 +172,8 @@
     "realtime_address" : "tcp://127.0.0.1:9696",
     "ringbuffer_name": "data_ringbuffer",
     "ringbuffer_size_bytes" : "200e6",
+    "pulse_buffer_name": "pulse_buffer",
+    "pulse_buffer_size": "1000000",
     "data_directory" : "/data/borealis_data",
     "rawacf_format" : "dmap",
     "log_handlers" : {

--- a/config/lab/lab_config.ini
+++ b/config/lab/lab_config.ini
@@ -172,12 +172,14 @@
     "realtime_address" : "tcp://eth1:9696",
     "ringbuffer_name": "data_ringbuffer",
     "ringbuffer_size_bytes" : "200e6",
+    "pulse_buffer_name": "pulse_buffer",
+    "pulse_buffer_size": "1000000",
     "data_directory" : "/data/borealis_data",
     "rawacf_format" : "hdf5",
     "log_handlers" : {
         "console" : {
             "enable" : true,
-            "level" : "INFO"
+            "level" : "VERBOSE"
         },
         "logfile" : {
             "enable" : true,

--- a/config/pgr/pgr_config.ini
+++ b/config/pgr/pgr_config.ini
@@ -172,6 +172,8 @@
     "realtime_address" : "tcp://127.0.0.1:9696",
     "ringbuffer_name": "data_ringbuffer",
     "ringbuffer_size_bytes" : "200e6",
+    "pulse_buffer_name": "pulse_buffer",
+    "pulse_buffer_size": "1000000",
     "data_directory" : "/data/borealis_data",
     "rawacf_format" : "dmap",
     "log_handlers" : {

--- a/config/rkn/rkn_config.ini
+++ b/config/rkn/rkn_config.ini
@@ -172,6 +172,8 @@
     "realtime_address" : "tcp://127.0.0.1:9696",
     "ringbuffer_name": "data_ringbuffer",
     "ringbuffer_size_bytes" : "200e6",
+    "pulse_buffer_name": "pulse_buffer",
+    "pulse_buffer_size": "1000000",
     "data_directory" : "/data/borealis_data",
     "rawacf_format" : "dmap",
     "log_handlers" : {

--- a/config/sas/sas_config.ini
+++ b/config/sas/sas_config.ini
@@ -1,6 +1,6 @@
 {
     "site_id" : "sas",
-    "gps_octoclock_addr" : "addr=192.168.10.131",
+    "gps_octoclock_addr" : "addr=192.168.10.3",
     "device_options" : "recv_frame_size=4000",
     "n200s" : [
         {
@@ -172,6 +172,8 @@
     "realtime_address" : "tcp://127.0.0.1:9696",
     "ringbuffer_name": "data_ringbuffer",
     "ringbuffer_size_bytes" : "200e6",
+    "pulse_buffer_name": "pulse_buffer",
+    "pulse_buffer_size": "1000000",
     "data_directory" : "/data/borealis_data",
     "rawacf_format" : "dmap",
     "log_handlers" : {

--- a/src/usrp_drivers/usrp_driver.cpp
+++ b/src/usrp_drivers/usrp_driver.cpp
@@ -250,7 +250,8 @@ void transmit(zmq::context_t &driver_c, USRP &usrp_d,
             );
 
             TIMEIT_IF_TRUE_OR_DEBUG(
-                true, COLOR_BLUE("TRANSMIT") << " sample unpack time: ", [&]() {
+                false,
+                COLOR_BLUE("TRANSMIT") << " sample unpack time: ", [&]() {
                   if (driver_packet.sob() == true) {
                     pulses.clear();
                   }

--- a/src/usrp_drivers/utils/driveroptions.cpp
+++ b/src/usrp_drivers/utils/driveroptions.cpp
@@ -258,6 +258,9 @@ DriverOptions::DriverOptions() {
   ringbuffer_name_ = config_pt.get<std::string>("ringbuffer_name");
   ringbuffer_size_bytes_ = boost::lexical_cast<double>(
       config_pt.get<std::string>("ringbuffer_size_bytes"));
+  pulse_buffer_name_ = config_pt.get<std::string>("pulse_buffer_name");
+  pulse_buffer_size_ = boost::lexical_cast<uint32_t>(
+      config_pt.get<std::string>("pulse_buffer_size"));
 
   driver_to_radctrl_identity_ = "DRIVER_RADCTRL_IDEN";
   driver_to_dsp_identity_ = "DRIVER_DSP_IDEN";
@@ -425,6 +428,15 @@ double DriverOptions::get_ringbuffer_size() const {
 }
 
 /**
+ * @brief      Gets the pulse buffer size.
+ *
+ * @return     The pulse buffer size.
+ */
+uint32_t DriverOptions::get_pulse_buffer_size() const {
+  return pulse_buffer_size_;
+}
+
+/**
  * @brief      Gets the all USRP receive channels.
  *
  * @return     The USRP receive channels.
@@ -512,4 +524,13 @@ std::string DriverOptions::get_brian_to_driver_identity() const {
  */
 std::string DriverOptions::get_ringbuffer_name() const {
   return ringbuffer_name_;
+}
+
+/**
+ * @brief      Gets the pulse buffer name.
+ *
+ * @return     The pulse buffer name.
+ */
+std::string DriverOptions::get_pulse_buffer_name() const {
+  return pulse_buffer_name_;
 }

--- a/src/usrp_drivers/utils/driveroptions.hpp
+++ b/src/usrp_drivers/utils/driveroptions.hpp
@@ -39,6 +39,7 @@ class DriverOptions : public Options {
   uint32_t get_lo_pwr() const;
   uint32_t get_agc_st() const;
   uint32_t get_test_mode() const;
+  uint32_t get_pulse_buffer_size() const;
   double get_tr_window_time() const;
   double get_agc_signal_read_delay() const;
   double get_ringbuffer_size() const;
@@ -52,6 +53,7 @@ class DriverOptions : public Options {
   std::string get_dsp_to_driver_identity() const;
   std::string get_brian_to_driver_identity() const;
   std::string get_ringbuffer_name() const;
+  std::string get_pulse_buffer_name() const;
 
  private:
   std::string devices_;
@@ -77,6 +79,7 @@ class DriverOptions : public Options {
   uint32_t agc_st_;
   uint32_t lo_pwr_;
   uint32_t test_mode_;
+  uint32_t pulse_buffer_size_;
   std::string router_address_;
   std::string driver_to_radctrl_identity_;
   std::string driver_to_dsp_identity_;
@@ -85,6 +88,7 @@ class DriverOptions : public Options {
   std::string dsp_to_driver_identity_;
   std::string brian_to_driver_identity_;
   std::string ringbuffer_name_;
+  std::string pulse_buffer_name_;
 };
 
 #endif  // SRC_USRP_DRIVERS_UTILS_DRIVEROPTIONS_HPP_

--- a/src/utils/options.py
+++ b/src/utils/options.py
@@ -67,6 +67,8 @@ class Options:
     rawacf_format: str = field(init=False)
     realtime_address: str = field(init=False)
     ringbuffer_name: str = field(init=False)
+    pulse_buffer_name: str = field(init=False)
+    pulse_buffer_size: int = field(init=False)
     router_address: str = field(init=False)
     site_id: str = field(init=False)
     standard_antenna_positions: bool = field(init=False)
@@ -303,6 +305,8 @@ class Options:
         self.router_address = raw_config["router_address"]
         self.realtime_address = raw_config["realtime_address"]
         self.ringbuffer_name = raw_config["ringbuffer_name"]
+        self.pulse_buffer_name = raw_config["pulse_buffer_name"]
+        self.pulse_buffer_size = int(raw_config["pulse_buffer_size"])
 
         self.data_directory = raw_config["data_directory"]
         self.rawacf_format = raw_config["rawacf_format"]

--- a/src/utils/protobuf/driverpacket.proto
+++ b/src/utils/protobuf/driverpacket.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package driverpacket;
 
 message DriverPacket {
-  repeated SamplesBuffer channel_samples = 1;
   uint32 sequence_num = 2;
   double rxrate = 3;
   double txrate = 4;
@@ -15,9 +14,6 @@ message DriverPacket {
   bool SOB = 10;
   bool EOB = 11;
   bool align_sequences = 12;
-
-  message SamplesBuffer {
-    repeated float real = 1;
-    repeated float imag = 2;
-  }
+  uint32 buffer_offset = 13;
+  uint32 numberoftransmitsamples = 14;
 }


### PR DESCRIPTION
Refactor the driver messages from `radar control` to `usrp driver` to use shared memory for the tx samples instead of using protobuff.
* Use shared memory to transfer between radar_control and usrp_driver.
* Adds fields to config file (similar to ringbuffer)
* Testing indicates faster message creation time for radar_control, roughly 20x speedup on lab computer.