### PR TITLE
Fixing rounding errors affecting two-stage filter mode.

### DIFF
--- a/src/rx_signal_processing.py
+++ b/src/rx_signal_processing.py
@@ -556,7 +556,9 @@ def main():
             detail["range_sep"] = np.float32(chan.range_sep)
             detail["tau_spacing"] = np.uint32(chan.tau_spacing)
             detail["num_range_gates"] = np.uint32(chan.num_ranges)
-            detail["first_range_off"] = np.uint32(chan.first_range / chan.range_sep)
+            detail["first_range_off"] = np.uint32(
+                round(chan.first_range / chan.range_sep)
+            )
 
             lag_phase_offsets = []
 

--- a/src/utils/signals.py
+++ b/src/utils/signals.py
@@ -387,9 +387,11 @@ class DSP:
                 np.arange(slice_info["num_range_gates"], dtype=np.int32)
                 + slice_info["first_range_off"]
             )
-            tau_in_samples = slice_info["tau_spacing"] * 1e-6 * output_sample_rate
-            lag_pulses_as_samples = np.array(slice_info["lags"], np.int32) * np.int32(
-                tau_in_samples
+            tau_in_samples = np.int32(
+                round(slice_info["tau_spacing"] * 1e-6 * output_sample_rate)
+            )
+            lag_pulses_as_samples = (
+                np.array(slice_info["lags"], np.int32) * tau_in_samples
             )
 
             # [num_range_gates, 1, 1]


### PR DESCRIPTION
Same issue present in borealis_postprocessors. `tau_spacing` was calculated as 7.999... , then truncated to an integer as 7 instead of 8. A similar calculation was being done for the offset to the first range, so I rounded that calculation as well before truncating.