### PR TITLE
Only write correlations to file if specified in slice

### DIFF
--- a/src/data_write.py
+++ b/src/data_write.py
@@ -418,12 +418,10 @@ class DataWrite:
             slice_data = aveperiod_data[slice_num]
             if slice_num in parsed_data.mainacfs_available:
                 slice_data.main_acfs = find_expectation_value(main_acfs[slice_num]["data"])
-
         for slice_num in xcfs:
             slice_data = aveperiod_data[slice_num]
             if slice_num in parsed_data.xcfs_available:
                 slice_data.xcfs = find_expectation_value(xcfs[slice_num]["data"])
-
         for slice_num in intf_acfs:
             slice_data = aveperiod_data[slice_num]
             if slice_num in parsed_data.intfacfs_available:
@@ -433,6 +431,8 @@ class DataWrite:
 
         all_slice_data = {}
         for slice_num, slice_data in aveperiod_data.items():
+            if getattr(slice_data, "main_acfs", None) is None:
+                continue
             two_hr_file_with_type = self.slice_filenames[slice_num].format(ext="rawacf")
             self._write_file(slice_data, two_hr_file_with_type, "rawacf")
 

--- a/src/data_write.py
+++ b/src/data_write.py
@@ -326,7 +326,7 @@ class DataWrite:
 
                 all_slice_data[rx_channel.slice_id] = parameters
 
-        if write_rawacf and data_parsing.mainacfs_available:
+        if write_rawacf and len(data_parsing.mainacfs_available) > 0:
             self._write_correlations(all_slice_data, data_parsing)
         if write_bfiq and data_parsing.bfiq_available:
             self._write_bfiq_params(all_slice_data, data_parsing)
@@ -416,16 +416,17 @@ class DataWrite:
 
         for slice_num in main_acfs:
             slice_data = aveperiod_data[slice_num]
-            slice_data.main_acfs = find_expectation_value(main_acfs[slice_num]["data"])
+            if slice_num in parsed_data.mainacfs_available:
+                slice_data.main_acfs = find_expectation_value(main_acfs[slice_num]["data"])
 
         for slice_num in xcfs:
             slice_data = aveperiod_data[slice_num]
-            if parsed_data.xcfs_available:
+            if slice_num in parsed_data.xcfs_available:
                 slice_data.xcfs = find_expectation_value(xcfs[slice_num]["data"])
 
         for slice_num in intf_acfs:
             slice_data = aveperiod_data[slice_num]
-            if parsed_data.intfacfs_available:
+            if slice_num in parsed_data.intfacfs_available:
                 slice_data.intf_acfs = find_expectation_value(
                     intf_acfs[slice_num]["data"]
                 )

--- a/src/experiment_prototype/interface_classes/sequences.py
+++ b/src/experiment_prototype/interface_classes/sequences.py
@@ -155,10 +155,12 @@ class Sequence(InterfaceClassBase):
         self.rxctrfreq = self.slice_dict[self.slice_ids[0]].rxctrfreq
 
         # if any slice has cfs flag set, set the sequence cfs_flag to true
-        self.cfs_flag = False
-        for slice_id in self.slice_ids:
-            if self.slice_dict[slice_id].cfs_flag:
-                self.cfs_flag = True
+        self.cfs_flag = any([self.slice_dict[x].cfs_flag for x in self.slice_ids])
+
+        # Determine whether correlations are needed for this sequence
+        self.acf = any([self.slice_dict[x].acf for x in self.slice_ids])
+        self.xcf = any([self.slice_dict[x].xcf for x in self.slice_ids])
+        self.acfint = any([self.slice_dict[x].acfint for x in self.slice_ids])
 
         if not self.cfs_flag:
             self.build_sequence_pulses()

--- a/src/radar_control.py
+++ b/src/radar_control.py
@@ -276,6 +276,10 @@ def create_dsp_message(radctrl_params):
     message.output_sample_rate = radctrl_params.sequence.output_rx_rate
     message.rx_ctr_freq = radctrl_params.sequence.rxctrfreq * 1.0e3
     message.cfs_scan_flag = radctrl_params.cfs_scan_flag
+    message.acf = radctrl_params.sequence.acf
+    message.xcf = radctrl_params.sequence.xcf
+    message.acfint = radctrl_params.sequence.acfint
+
     if radctrl_params.cfs_scan_flag:
         message.cfs_fft_n = radctrl_params.aveperiod.cfs_fft_n
 
@@ -322,6 +326,9 @@ def create_dsp_message(radctrl_params):
         chan_add.range_sep = slice_dict[slice_id].range_sep
         chan_add.rx_intf_antennas = slice_dict[slice_id].rx_intf_antennas
         chan_add.pulses = slice_dict[slice_id].pulse_sequence
+        chan_add.acf = slice_dict[slice_id].acf
+        chan_add.xcf = slice_dict[slice_id].xcf
+        chan_add.acfint = slice_dict[slice_id].acfint
 
         main_bms = beam_dict[slice_id]["main"]
         intf_bms = beam_dict[slice_id]["intf"]

--- a/src/rx_signal_processing.py
+++ b/src/rx_signal_processing.py
@@ -61,6 +61,9 @@ class RxProcessingParameters:
     intf_antennas: list
     filter_taps: list
     downsample_rates: list
+    acf: bool
+    xcf: bool
+    acfint: bool
     cfs_scan_flag: bool
     samples_needed: int
     rx_rate: float
@@ -114,19 +117,16 @@ def fill_datawrite_message(processed_data, slice_details, data_outputs, cfs_scan
             processed_data.add_output_dataset(output_dataset)
             # if a clear frequency search was performed, add cfs data to message
         else:
-            main_corrs = data_outputs["main_corrs"][sd["slice_num"]]
-            output_dataset.main_acf_shm = add_array(main_corrs)
+            if "main_corrs" in data_outputs:
+                main_corrs = data_outputs["main_corrs"][sd["slice_num"]]
+                output_dataset.main_acf_shm = add_array(main_corrs)
 
-            intf_available = True
-            try:
+            if "intf_corrs" in data_outputs:
                 intf_corrs = data_outputs["intf_corrs"][sd["slice_num"]]
-                cross_corrs = data_outputs["cross_corrs"][sd["slice_num"]]
-            except KeyError:
-                # No interferometer data
-                intf_available = False
-
-            if intf_available:
                 output_dataset.intf_acf_shm = add_array(intf_corrs)
+
+            if "cross_corrs" in data_outputs:
+                cross_corrs = data_outputs["cross_corrs"][sd["slice_num"]]
                 output_dataset.xcf_shm = add_array(cross_corrs)
 
             processed_data.add_output_dataset(output_dataset)
@@ -182,14 +182,14 @@ def sequence_worker(options, ringbuffer):
         # of existing data without making a copy.
         if cupy_available:
             if rx_params.end_sample > ringbuffer.shape[1]:
-                piece1 = ringbuffer[:, rx_params.start_sample :]
+                piece1 = ringbuffer[:, rx_params.start_sample:]
                 piece2 = ringbuffer[:, : rx_params.end_sample - ringbuffer.shape[1]]
                 tmp1 = xp.array(piece1)
                 tmp2 = xp.array(piece2)
                 sequence_samples = xp.concatenate((tmp1, tmp2), axis=1)
             else:
                 sequence_samples = xp.array(
-                    ringbuffer[:, rx_params.start_sample : rx_params.end_sample]
+                    ringbuffer[:, rx_params.start_sample:rx_params.end_sample]
                 )
         else:
             sequence_samples = ringbuffer.take(indices, axis=1, mode="wrap")
@@ -252,12 +252,15 @@ def sequence_worker(options, ringbuffer):
             main_processor.apply_filters(main_sequence_samples)
             main_processor.move_filter_results()
             main_processor.beamform(rx_params.main_beam_angles)
-            main_corrs = DSP.correlations_from_samples(
-                main_processor.beamformed_samples,
-                main_processor.beamformed_samples,
-                rx_params.output_sample_rate,
-                rx_params.slice_details,
-            )
+            if rx_params.acf:
+                for slice_info in rx_params.slice_details.values():
+                    slice_info['skip'] = slice_info['acf']
+                main_corrs = DSP.correlations_from_samples(
+                    main_processor.beamformed_samples,
+                    main_processor.beamformed_samples,
+                    rx_params.output_sample_rate,
+                    rx_params.slice_details,
+                )
             log_dict["main_dsp_time"] = (time.perf_counter() - mark_timer) * 1e3
 
             # Process intf samples if intf exists
@@ -266,7 +269,7 @@ def sequence_worker(options, ringbuffer):
             log_dict["intf antennas"] = rx_params.intf_antennas
             if len(rx_params.intf_antennas) > 0:
                 intf_sequence_samples = sequence_samples[
-                    len(options.rx_main_antennas) :, :
+                    len(options.rx_main_antennas):, :
                 ]
                 intf_sequence_samples_shape = intf_sequence_samples.shape
                 intf_processor = DSP(
@@ -278,18 +281,24 @@ def sequence_worker(options, ringbuffer):
                 intf_processor.apply_filters(intf_sequence_samples)
                 intf_processor.move_filter_results()
                 intf_processor.beamform(rx_params.intf_beam_angles)
-                intf_corrs = DSP.correlations_from_samples(
-                    intf_processor.beamformed_samples,
-                    intf_processor.beamformed_samples,
-                    rx_params.output_sample_rate,
-                    rx_params.slice_details,
-                )
-                cross_corrs = DSP.correlations_from_samples(
-                    intf_processor.beamformed_samples,
-                    main_processor.beamformed_samples,
-                    rx_params.output_sample_rate,
-                    rx_params.slice_details,
-                )
+                if rx_params.acfint:
+                    for slice_info in rx_params.slice_details.values():
+                        slice_info['skip'] = slice_info['acfint']
+                    intf_corrs = DSP.correlations_from_samples(
+                        intf_processor.beamformed_samples,
+                        intf_processor.beamformed_samples,
+                        rx_params.output_sample_rate,
+                        rx_params.slice_details,
+                    )
+                if rx_params.xcf:
+                    for slice_info in rx_params.slice_details.values():
+                        slice_info['skip'] = slice_info['xcf']
+                    cross_corrs = DSP.correlations_from_samples(
+                        intf_processor.beamformed_samples,
+                        main_processor.beamformed_samples,
+                        rx_params.output_sample_rate,
+                        rx_params.slice_details,
+                    )
             log_dict["intf_dsp_time"] = (time.perf_counter() - mark_timer) * 1e3
 
         # Tell brian DSP how long it took
@@ -442,11 +451,14 @@ def sequence_worker(options, ringbuffer):
             rx_params.processed_data.num_samps = beamformed_m.shape[-1]
             main_processor.shared_mem["bfiq"].close()
 
-            data_outputs["main_corrs"] = main_corrs
+            if rx_params.acf:
+                data_outputs["main_corrs"] = main_corrs
 
             if len(rx_params.intf_antennas) > 0:
-                data_outputs["cross_corrs"] = cross_corrs
-                data_outputs["intf_corrs"] = intf_corrs
+                if rx_params.xcf:
+                    data_outputs["cross_corrs"] = cross_corrs
+                if rx_params.acfint:
+                    data_outputs["intf_corrs"] = intf_corrs
                 rx_params.processed_data.bfiq_intf_shm = intf_processor.shared_mem[
                     "bfiq"
                 ].name
@@ -559,6 +571,9 @@ def main():
             detail["first_range_off"] = np.uint32(
                 round(chan.first_range / chan.range_sep)
             )
+            detail["acf"] = chan.acf
+            detail["xcf"] = chan.xcf
+            detail["acfint"] = chan.acfint
 
             lag_phase_offsets = []
 
@@ -711,6 +726,9 @@ def main():
             intf_antennas,
             dm_scheme_taps,
             dm_rates,
+            sqn_meta_message.acf,
+            sqn_meta_message.xcf,
+            sqn_meta_message.acfint,
             cfs_scan_flag,
             samples_needed,
             rx_rate,

--- a/src/rx_signal_processing.py
+++ b/src/rx_signal_processing.py
@@ -253,8 +253,8 @@ def sequence_worker(options, ringbuffer):
             main_processor.move_filter_results()
             main_processor.beamform(rx_params.main_beam_angles)
             if rx_params.acf:
-                for slice_info in rx_params.slice_details.values():
-                    slice_info['skip'] = slice_info['acf']
+                for slice_info in rx_params.slice_details:
+                    slice_info['skip'] = not slice_info['acf']
                 main_corrs = DSP.correlations_from_samples(
                     main_processor.beamformed_samples,
                     main_processor.beamformed_samples,
@@ -282,8 +282,8 @@ def sequence_worker(options, ringbuffer):
                 intf_processor.move_filter_results()
                 intf_processor.beamform(rx_params.intf_beam_angles)
                 if rx_params.acfint:
-                    for slice_info in rx_params.slice_details.values():
-                        slice_info['skip'] = slice_info['acfint']
+                    for slice_info in rx_params.slice_details:
+                        slice_info['skip'] = not slice_info['acfint']
                     intf_corrs = DSP.correlations_from_samples(
                         intf_processor.beamformed_samples,
                         intf_processor.beamformed_samples,
@@ -291,8 +291,8 @@ def sequence_worker(options, ringbuffer):
                         rx_params.slice_details,
                     )
                 if rx_params.xcf:
-                    for slice_info in rx_params.slice_details.values():
-                        slice_info['skip'] = slice_info['xcf']
+                    for slice_info in rx_params.slice_details:
+                        slice_info['skip'] = not slice_info['xcf']
                     cross_corrs = DSP.correlations_from_samples(
                         intf_processor.beamformed_samples,
                         main_processor.beamformed_samples,

--- a/src/utils/data_aggregator.py
+++ b/src/utils/data_aggregator.py
@@ -25,14 +25,14 @@ class Aggregator:
     antenna_iq_available: bool = False
     bfiq_accumulator: dict = field(default_factory=dict)
     bfiq_available: bool = False
-    intfacfs_available: bool = False
+    intfacfs_available: set = field(default_factory=set)
     # init True so that logical AND works properly in update() method
     gps_locked: bool = True
     gps_to_system_time_diff: float = 0.0
     intfacfs_accumulator: dict = field(default_factory=dict)
     lp_status_word: int = 0b0
     mainacfs_accumulator: dict = field(default_factory=dict)
-    mainacfs_available: bool = False
+    mainacfs_available: set = field(default_factory=set)
     options: Options = None
     processed_data: ProcessedSequenceMessage = field(init=False)
     rawrf_available: bool = False
@@ -42,7 +42,7 @@ class Aggregator:
     slice_ids: set = field(default_factory=set)
     timestamps: list[float] = field(default_factory=list)
     xcfs_accumulator: dict = field(default_factory=dict)
-    xcfs_available: bool = False
+    xcfs_available: set = field(default_factory=set)
 
     def _get_accumulators(self):
         """Returns a list of all accumulator dictionaries in this object."""
@@ -85,16 +85,16 @@ class Aggregator:
                 shm.close()
                 shm.unlink()
 
-            if data_set.main_acf_shm:
-                self.mainacfs_available = True
+            if data_set.main_acf_shm is not None:
+                self.mainacfs_available.update(slice_id)
                 accumulate_data(self.mainacfs_accumulator, data_set.main_acf_shm)
 
-            if data_set.xcf_shm:
-                self.xcfs_available = True
+            if data_set.xcf_shm is not None:
+                self.xcfs_available.update(slice_id)
                 accumulate_data(self.xcfs_accumulator, data_set.xcf_shm)
 
-            if data_set.intf_acf_shm:
-                self.intfacfs_available = True
+            if data_set.intf_acf_shm is not None:
+                self.intfacfs_available.update(slice_id)
                 accumulate_data(self.intfacfs_accumulator, data_set.intf_acf_shm)
 
     def parse_bfiq(self):

--- a/src/utils/data_aggregator.py
+++ b/src/utils/data_aggregator.py
@@ -86,15 +86,15 @@ class Aggregator:
                 shm.unlink()
 
             if data_set.main_acf_shm is not None:
-                self.mainacfs_available.update(slice_id)
+                self.mainacfs_available.add(slice_id)
                 accumulate_data(self.mainacfs_accumulator, data_set.main_acf_shm)
 
             if data_set.xcf_shm is not None:
-                self.xcfs_available.update(slice_id)
+                self.xcfs_available.add(slice_id)
                 accumulate_data(self.xcfs_accumulator, data_set.xcf_shm)
 
             if data_set.intf_acf_shm is not None:
-                self.intfacfs_available.update(slice_id)
+                self.intfacfs_available.add(slice_id)
                 accumulate_data(self.intfacfs_accumulator, data_set.intf_acf_shm)
 
     def parse_bfiq(self):

--- a/src/utils/message_formats.py
+++ b/src/utils/message_formats.py
@@ -110,6 +110,9 @@ class RxChannel:
     beam_phases: np.ndarray = None
     lags: list[Lag] = field(default_factory=list)
     pulses: list = field(default_factory=list)
+    acf: bool = False
+    xcf: bool = False
+    acfint: bool = False
 
     def add_lag(self, lag: Lag):
         """Add a Lag dataclass to the message."""
@@ -132,6 +135,9 @@ class SequenceMetadataMessage:
     rx_ctr_freq: float = None
     decimation_stages: list[DecimationStageMessage] = field(default_factory=list)
     rx_channels: list[RxChannel] = field(default_factory=list)
+    acf: bool = False
+    xcf: bool = False
+    acfint: bool = False
     cfs_scan_flag: bool = False
     cfs_fft_n: int = None
 

--- a/src/utils/signals.py
+++ b/src/utils/signals.py
@@ -1,6 +1,6 @@
 """
 signals
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~
 This file contains the digital signal processing functionality of Borealis. This includes generation of pulses,
 determination of antenna phases for beamforming, filtering and downsampling of received signals, beamforming of
 filtered signals, and extraction of lag profiles from beamformed samples.
@@ -379,7 +379,7 @@ class DSP:
         """
         values = []
         for s, slice_info in enumerate(slice_index_details):
-            if slice_info["lags"].size == 0:
+            if slice_info.get('skip', False) or slice_info["lags"].size == 0:
                 values.append(np.array([]))
                 continue
 

--- a/src/utils/signals.py
+++ b/src/utils/signals.py
@@ -378,7 +378,7 @@ class DSP:
         :rtype:     list[ndarray]
         """
         values = []
-        for s, slice_info in enumerate(slice_index_details):
+        for slc, slice_info in enumerate(slice_index_details):
             if slice_info.get('skip', False) or slice_info["lags"].size == 0:
                 values.append(np.array([]))
                 continue
@@ -415,8 +415,8 @@ class DSP:
             for lag in range(row.shape[1]):
                 values_for_slice[:, :, lag] = np.einsum(
                     "ij,ij->ji",
-                    beamformed_samples_1[s, :, row[:, lag]],
-                    beamformed_samples_2[s, :, col[:, lag]].conj(),
+                    beamformed_samples_1[slc, :, row[:, lag]],
+                    beamformed_samples_2[slc, :, col[:, lag]].conj(),
                 )
 
             # [num_beams, num_range_gates, num_lags]


### PR DESCRIPTION
Fixes a bug wherein Borealis would write `intf_acfs` to file if writing rawacf files, regardless of value of `acfint` in the slice definition. Similarly with `xcfs`. 

I've tested with a two-slice concurrent-interfaced experiment, toggling `acf, `acfint`, and `xcf` for one slice at a time, verifying that the fields are only written to file for the specified slices. Also, verified that rawacf files are only written when `acf` is set for a slice (if it is False, `acfint` and `xcf` are overwritten to False too, regardless of their specification in the slice definition).