### PR TITLE
Documentation and error-checking for page-lock of critical buffers.

### DIFF
--- a/docs/source/setup_software.rst
+++ b/docs/source/setup_software.rst
@@ -163,11 +163,15 @@ the note when running ``install_radar_deps.py``.
     cd $BOREALISPATH
     sudo -E python3 scripts/install_radar_deps.py [radar code] $BOREALISPATH --python-version=3.11 2>&1
 
-#. Edit ``/etc/security/limits.conf`` (as root) to add the following line that allows UHD to set
-   thread priority. UHD automatically tries to boost its thread scheduling priority, so it will fail
-   if the user executing UHD doesn't have permission. ::
+#. Edit ``/etc/security/limits.conf`` (as root) to add the following lines.
+   The first line allows UHD to set thread priority. UHD automatically tries to boost its thread scheduling priority, so it will fail
+   if the user executing UHD doesn't have permission.
+   The second line removes limits on the amount of page-locked memory and shared memory that a process can allocate
+   for the ``radar`` user, which we use to prevent the ringbuffer from being swapped to disk. Switch ``radar`` with the user that
+   will run borealis on your computer::
 
     @users - rtprio 99
+    radar - memlock unlimited
 
 #. Once all dependencies are resolved, use ``scons`` to build the system.
    ``SCONSFLAGS`` variable can be added to ``.profile`` to hold any flags such

--- a/src/usrp_drivers/usrp_driver.cpp
+++ b/src/usrp_drivers/usrp_driver.cpp
@@ -1,4 +1,5 @@
 /*Copyright 2016 SuperDARN*/
+#include <errno.h>
 #include <stdint.h>
 #include <sys/mman.h>
 #include <unistd.h>
@@ -261,8 +262,10 @@ void transmit(zmq::context_t &driver_c, USRP &usrp_d,
 
   SharedMemoryHandler pulse_buf(driver_options.get_pulse_buffer_name());
   pulse_buf.create_shr_mem(total_pbuf_size);
-  mlock(pulse_buf.get_shrmem_addr(), total_pbuf_size);
-
+  if (mlock(pulse_buf.get_shrmem_addr(), total_pbuf_size) != 0) {
+    std::cout << "Failed to mlock pulse buffer of size " << total_pbuf_size
+              << "; error " << errno << " " << strerror(errno) << std::endl;
+  }
   std::vector<std::complex<float> *> pulse_buffer_starts;
   for (uint32_t i = 0; i < tx_channels.size(); i++) {
     auto p_ptr =
@@ -692,7 +695,13 @@ void receive(zmq::context_t &driver_c, USRP &usrp_d,
   auto total_rbuf_size =
       receive_channels.size() * ringbuffer_size * sizeof(std::complex<float>);
   shrmem.create_shr_mem(total_rbuf_size);
-  mlock(shrmem.get_shrmem_addr(), total_rbuf_size);
+
+  // Attempt to page-lock memory to ensure fast transfer to GPU
+
+  if (mlock(shrmem.get_shrmem_addr(), total_rbuf_size) != 0) {
+    std::cout << "Failed to mlock ringbuffer of size " << total_rbuf_size
+              << "; error " << errno << " " << strerror(errno) << std::endl;
+  }
 
   std::vector<std::complex<float> *> buffer_ptrs_start;
 


### PR DESCRIPTION
* Added step to `setup_software.rst` explaining how to increase system limits to allow ringbuffer to be page-locked.
* Log errors in `mlock` calls of `usrp_driver` for debugging on any system that has issues.