### PR TITLE
Only restart radar if service enabled.

### DIFF
--- a/scripts/apcupsd/offbattery
+++ b/scripts/apcupsd/offbattery
@@ -28,7 +28,7 @@ if [[ -f $FLAG_FILE ]]; then
         # attempting to run the radar after power is restored)
         msg=$(systemctl is-enabled restart_borealis.service)
         retval=$?
-        if [[ $retval -eq 1 ]]; then
+        if [[ $retval -ne 0 ]]; then
           # The restart_borealis service will start the radar if it isn't already running and handle
           # any further restarts.
           systemctl restart restart_borealis.service

--- a/scripts/apcupsd/offbattery
+++ b/scripts/apcupsd/offbattery
@@ -24,9 +24,15 @@ if [[ -f $FLAG_FILE ]]; then
                 pkill -9 -P "$PID"
         fi
 
-        # The restart_borealis service will start the radar if it isn't already running and handle
-        # any further restarts.
-        systemctl restart restart_borealis.service
+        # only restart this service if it is enabled (prevents multiple computers from
+        # attempting to run the radar after power is restored)
+        msg=$(systemctl is-enabled restart_borealis.service)
+        retval=$?
+        if [[ $retval -eq 1 ]]; then
+          # The restart_borealis service will start the radar if it isn't already running and handle
+          # any further restarts.
+          systemctl restart restart_borealis.service
+        fi
 
         # Clean up temporary files
         rm $PID_FILE


### PR DESCRIPTION
* Prevents multiple computers from trying to run radar when APC goes off battery.