### PR TITLE
Scheduling fixes and new discretionary time default experiment.

### DIFF
--- a/scheduler/central_scd_server.py
+++ b/scheduler/central_scd_server.py
@@ -26,7 +26,7 @@ SWG_GIT_REPO = "https://github.com/SuperDARN/schedules.git"
 EXPERIMENTS = {
     "sas": {
         "common_time": "twofsound",
-        "discretionary_time": "twofsound",
+        "discretionary_time": "full_fov",
         "htr_common_time": "twofsound",
         "themis_time": "themisscan",
         "special_time_normal": "twofsound",
@@ -37,7 +37,7 @@ EXPERIMENTS = {
     },
     "pgr": {
         "common_time": "twofsound",
-        "discretionary_time": "twofsound",
+        "discretionary_time": "full_fov",
         "htr_common_time": "twofsound",
         "themis_time": "themisscan",
         "special_time_normal": "twofsound",
@@ -48,7 +48,7 @@ EXPERIMENTS = {
     },
     "rkn": {
         "common_time": "twofsound",
-        "discretionary_time": "twofsound",
+        "discretionary_time": "full_fov",
         "htr_common_time": "twofsound",
         "themis_time": "themisscan",
         "special_time_normal": "twofsound",
@@ -59,7 +59,7 @@ EXPERIMENTS = {
     },
     "inv": {
         "common_time": "twofsound",
-        "discretionary_time": "twofsound",
+        "discretionary_time": "full_fov",
         "htr_common_time": "twofsound",
         "themis_time": "themisscan",
         "special_time_normal": "twofsound",
@@ -70,7 +70,7 @@ EXPERIMENTS = {
     },
     "cly": {
         "common_time": "twofsound",
-        "discretionary_time": "twofsound",
+        "discretionary_time": "full_fov",
         "htr_common_time": "twofsound",
         "themis_time": "themisscan",
         "special_time_normal": "twofsound",
@@ -81,7 +81,7 @@ EXPERIMENTS = {
     },
     "lab": {
         "common_time": "twofsound",
-        "discretionary_time": "twofsound",
+        "discretionary_time": "full_fov",
         "htr_common_time": "twofsound",
         "themis_time": "themisscan",
         "special_time_normal": "twofsound",

--- a/scheduler/central_scd_server.py
+++ b/scheduler/central_scd_server.py
@@ -93,7 +93,7 @@ EXPERIMENTS = {
 }
 
 
-class SWG(object):
+class SWG:
     """Holds the data needed for processing a SWG file."""
 
     def __init__(self, scd_dir):

--- a/scheduler/central_scd_server.py
+++ b/scheduler/central_scd_server.py
@@ -354,10 +354,7 @@ def main():
             if not errors:
                 success_msg = "All swg lines successfully scheduled.\n"
                 for site, site_scd in zip(sites, site_scds):
-                    yyyymmdd = today.strftime("%Y%m%d")
-                    hhmm = today.strftime("%H:%M")
-
-                    new_lines = site_scd.get_relevant_lines(yyyymmdd, hhmm)
+                    new_lines = site_scd.get_relevant_lines(today)
 
                     text_lines = [str(x) for x in new_lines]
 

--- a/scheduler/scd_utils.py
+++ b/scheduler/scd_utils.py
@@ -137,11 +137,14 @@ class ScheduleLine:
                 ]
                 + args,
                 check=True,
+                stderr=sp.PIPE,
             )
         except sp.CalledProcessError as e:
             raise ScheduleError(
                 "Experiment could not be scheduled due to errors in experiment.\n"
                 + str(e)
+                + "\n\n"
+                + e.stderr.decode("utf-8")
             )
 
     @classmethod

--- a/scheduler/scd_utils.py
+++ b/scheduler/scd_utils.py
@@ -132,7 +132,7 @@ class ScheduleLine:
         try:
             sp.run(
                 [
-                    f"{os.environ['BOREALISPATH']}/borealis_env{os.environ['PYTHON_VERSION']}/bin/python3",
+                    f"{os.environ['VIRTUAL_ENV']}/bin/python3",
                     f"{os.environ['BOREALISPATH']}/tests/experiments/test_as_site.py",
                 ]
                 + args,
@@ -267,7 +267,7 @@ class SCDUtils:
         ).stdout
         if retval is None:
             retval = b""
-        return retval.decode('utf-8')
+        return retval.decode("utf-8")
 
     def create_line(
         self,
@@ -401,6 +401,9 @@ class SCDUtils:
 
         :raises ValueError: If line parameters are invalid or if line is a duplicate.
         """
+        if kwargs is None:
+            kwargs = list()
+
         new_line = self.create_line(
             yyyymmdd,
             hhmm,

--- a/src/brian.py
+++ b/src/brian.py
@@ -279,6 +279,9 @@ def main():
     args = parser.parse_args()
 
     options = Options()
+    if not os.path.exists(options.log_directory):
+        raise RuntimeError(f"log_directory {options.log_directory} does not exist")
+
     threads = [
         threading.Thread(
             target=router, args=(options,), kwargs={"realtime_off": args.realtime_off}

--- a/src/data_write.py
+++ b/src/data_write.py
@@ -607,6 +607,9 @@ def main():
     args = dw_parser().parse_args()
 
     options = Options()
+    if not os.path.exists(options.data_directory):
+        raise RuntimeError(f"data_directory {options.data_directory} does not exist")
+
     if args.rawacf_format is None:
         rawacf_format = options.rawacf_format
     else:

--- a/src/radar_control.py
+++ b/src/radar_control.py
@@ -703,6 +703,8 @@ def main(exp_name, scheduling_mode, embargo, **kwargs):
 
     # Get config options
     options = Options()
+    if not os.path.exists(options.hdw_path):
+        raise ValueError(f"hdw_path directory {options.hdw_path} does not exist")
 
     # Setup sockets
     # Socket to send pulse samples over

--- a/src/utils/options.py
+++ b/src/utils/options.py
@@ -136,7 +136,9 @@ class Options:
     )  #: Minimum duration between pulses in a pulse sequence [μs]
     num_beams: int = field(init=False)  #: Default number of beam directions to scan
     num_ranges: int = field(init=False)  #: Default number of range gates
-    scan_direction: str = field(init=False)  #: Scan direction, "clockwise" or "counterclockwise"
+    scan_direction: str = field(
+        init=False
+    )  #: Scan direction, "clockwise" or "counterclockwise"
 
     n200_addrs: list[str] = field(init=False)
     n200_count: int = field(init=False)
@@ -544,16 +546,11 @@ class Options:
         if self.num_ranges <= 0:
             raise ValueError("num_ranges must be > 0")
         if self.scan_direction not in ["clockwise", "counterclockwise"]:
-            raise ValueError("scan_direction must be either `clockwise` or `counterclockwise`")
+            raise ValueError(
+                "scan_direction must be either `clockwise` or `counterclockwise`"
+            )
 
         # TODO: Test that realtime_address and router_address are valid addresses
-
-        if not os.path.exists(self.data_directory):
-            raise ValueError(f"data_directory {self.data_directory} does not exist")
-        if not os.path.exists(self.log_directory):
-            raise ValueError(f"log_directory {self.log_directory} does not exist")
-        if not os.path.exists(self.hdw_path):
-            raise ValueError(f"hdw_path directory {self.hdw_path} does not exist")
 
     def __str__(self):
         return_str = f"""    site_id = {self.site_id} \

--- a/tests/simulators/steamed_sham.py
+++ b/tests/simulators/steamed_sham.py
@@ -87,7 +87,7 @@ def steamed_hams_parser():
         help="The name of the module in the experiments directory that contains your experiment class, e.g. `normalscan`",
     )
     parser.add_argument(
-        "runtime_mode",
+        "run_mode",
         help="""Runtime mode.
         `release`: runs Python modules with `-O -u` for faster performance, generates antennas_iq and rawacf files.
         `debug`: runs `usrp_driver` module with `gdb`, limits performance to at most one pulse sequence per second.
@@ -175,7 +175,7 @@ if __name__ == "__main__":
     # Configure python first, starting with options for each module
     options = {
         "brian": "",
-        "radar_control": f"{args.experiment_module} {args.scheduling_mode_type}",
+        "radar_control": f"{args.experiment_module} {args.scheduling_mode}",
         "data_write": f"{data_write_args}",
         "realtime": "",
         "rx_signal_processing": "",


### PR DESCRIPTION
Fixes scheduling errors.

* Use the sourced `$VIRTUAL_ENV/bin/python3` instead of `$BOREALISENV/bin/python3` when testing experiments in a subprocess in `SCDUtils.test()`. This allows a non-radar computer (e.g. sdc-serv) to run the tests. This bug was recently introduced.
* Move some `Options` class checks to radar modules data_write, brian, and radar_control. Namely, verification of certain directories. These checks are irrelevant for a scheduling-only computer which doesn't require those directories.
* Fixed a bug in superdarn_common_fields.py where reverse-scanning experiment slices fail to build.
* Change the default discretionary time experiment from `twofsound` to `full_fov`.