### PR TITLE
Fix for running restart_borealis system service

### DIFF
--- a/scripts/restart_borealis.service
+++ b/scripts/restart_borealis.service
@@ -5,9 +5,10 @@ Description=Restart borealis daemon
 
 [Service]
 User=radar
-Environment="TERM=xterm-256color"
 ExecStart=/usr/local/bin/restart_borealis.daemon
 Restart=always
+# Needed for OpenSUSE Leap 16.0
+SELinuxContext=unconfined_u:unconfined_r:unconfined_t:s0
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/restart_borealis.service
+++ b/scripts/restart_borealis.service
@@ -5,6 +5,7 @@ Description=Restart borealis daemon
 
 [Service]
 User=radar
+Environment="TERM=xterm-256color"
 ExecStart=/usr/local/bin/restart_borealis.daemon
 Restart=always
 


### PR DESCRIPTION
On OpenSUSE Leap 16.0, running `restart_borealis.service` would cause the `steamed_hams.py` command scheduled by `at` to fail silently. The issue is due to Leap 16.0 using SELinux as the default security software, versus Leap 15.x using a different software. 

The change to `restart_borealis.service` ensures that the same SELinux context is used when running `restart_borealis.daemon` from the login terminal, or from the system service.